### PR TITLE
support private ALBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you’re bringing your own infrastructure (e.g. Kubernetes cluster, Redis, Po
 > cd paragon-on-prem
 > make -s build
 > make -s tf-version
+> yarn install
 ```
 
 Confirm that when running `make -s tf-version`, you see the following output or similar:
@@ -172,7 +173,9 @@ Run the following command to provision the infrastructure:
 > make -s deploy-infra
 ```
 
-You should see Terraform initialize the modules and prepare a remote plan. Type `yes` to create the infrastructure.
+You should see Terraform initialize the modules and prepare a remote plan. Type `yes` to create the infrastructure. 
+
+Note that if this is a new account or workspace that you may have to approve it in the web UI also. This can be bypassed in the future by selecting "Auto apply" under the general workspace settings.
 
 Confirm that all the resources are created.
 

--- a/terraform/workspaces/paragon/helm/helm.tf
+++ b/terraform/workspaces/paragon/helm/helm.tf
@@ -152,6 +152,16 @@ resource "helm_release" "paragon_on_prem" {
     }
   }
 
+  # configures whether the load balancer is 'internet-facing' (public) or 'internal' (private)
+  dynamic "set" {
+    for_each = var.microservices
+
+    content {
+      name  = "${set.key}.ingress.schema"
+      value = var.ingress_scheme
+    }
+  }
+
   set {
     name  = "global.env.K8_VERSION"
     value = "1.22"
@@ -235,6 +245,16 @@ resource "helm_release" "paragon_monitoring" {
     content {
       name  = "${set.key}.ingress.load_balancer_name"
       value = var.aws_workspace
+    }
+  }
+
+  # configures whether the load balancer is 'internet-facing' (public) or 'internal' (private)
+  dynamic "set" {
+    for_each = var.public_monitors
+
+    content {
+      name  = "${set.key}.ingress.schema"
+      value = var.ingress_scheme
     }
   }
 

--- a/terraform/workspaces/paragon/helm/variables.tf
+++ b/terraform/workspaces/paragon/helm/variables.tf
@@ -85,3 +85,8 @@ variable "public_monitors" {
     public_url = string
   }))
 }
+
+variable "ingress_scheme" {
+  description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
+  type        = string
+}

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -26,6 +26,7 @@ module "helm" {
   public_monitors  = local.public_monitors
   monitors_enabled = var.monitors_enabled
   monitor_version  = var.monitor_version
+  ingress_scheme   = var.ingress_scheme
 
   acm_certificate_arn = module.alb.acm_certificate_arn
 }

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -90,6 +90,12 @@ variable "helm_values" {
   })
 }
 
+variable "ingress_scheme" {
+  description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
+  type        = string
+  default     = "internet-facing"
+}
+
 locals {
   _microservices = {
     "cerberus" = {


### PR DESCRIPTION
### Issues Closed

- PARA-7495

### Brief Summary

Adds variable to enable private ALB usage in AWS.

### Detailed Summary

The default scheme for the AWS ALB is for it to be internet-facing. However there are scenarios where DNS and routing may originate from a peered VPC so this ALB can and should be private. This change will make the ALB private with environment variable `INGRESS_SCHEME = internal`. The default is to retain the previous scheme which is `INGRESS_SCHEME = internet-facing`.

### Changes

- added `ingress_scheme` variable to set the `alb.ingress.kubernetes.io/scheme` value in each potentially public facing chart's ingress.yml.
