### PR TITLE
fix: failed parsing key > list must terminate with

### DIFF
--- a/terraform/workspaces/paragon/monitors/grafana.tf
+++ b/terraform/workspaces/paragon/monitors/grafana.tf
@@ -66,7 +66,7 @@ resource "random_string" "grafana_admin_password" {
   length      = 16
   min_upper   = 2
   min_lower   = 2
-  min_special = 2
+  min_special = 0
   numeric     = true
   special     = false
   lower       = true


### PR DESCRIPTION
The generated password, although having special characters turned off, has a min_special value of 2. This randomly generated some passwords that caused problems down the line.