### PR TITLE
fix(infra): replace apt-key location from cloud.google to k8s.io

### DIFF
--- a/terraform/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
+++ b/terraform/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
@@ -26,7 +26,9 @@ eksctl version
 
 # install kubectl
 sudo apt-get install -y apt-transport-https ca-certificates curl
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+# use k8s key instead of google key do to recent changes
+# see: https://github.com/kubernetes/k8s.io/pull/4837#issuecomment-1557062278
+sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl


### PR DESCRIPTION
The original location recently started returning the GPG key in ascii instead of the binary format.

See: https://github.com/kubernetes/k8s.io/pull/4837#issuecomment-1557062278