### PR TITLE
Configurable K8 Version + EBS CSI Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,25 +147,26 @@ Copy the environment variable files into the `.secure/` directory and remove `.e
 
 **Required**
 
- - `AWS_ACCESS_KEY_ID`: your AWS access key id
- - `AWS_REGION`: the AWS region to deploy resources to
- - `AWS_SECRET_ACCESS_KEY`: your AWS secret access key
- - `TF_ORGANIZATION`**:** the name of the organization your Terraform account belongs to
- - `TF_TOKEN`: your Terraform API key
- - `TF_WORKSPACE`**:** the Terraform workspace for the infrastructure
+- `AWS_ACCESS_KEY_ID`: your AWS access key id
+- `AWS_REGION`: the AWS region to deploy resources to
+- `AWS_SECRET_ACCESS_KEY`: your AWS secret access key
+- `TF_ORGANIZATION`**:** the name of the organization your Terraform account belongs to
+- `TF_TOKEN`: your Terraform API key
+- `TF_WORKSPACE`**:** the Terraform workspace for the infrastructure
 
 **Optional**
 
- - `AWS_SESSION_TOKEN`: the AWS session token for authenticating Terraform
- - `DISABLE_CLOUDTRAIL`: Set to `false` to disable creation of Cloudtrail resources
- - `DISABLE_DOCKER_VERIFICATION`: Set to `false` when running the installer outside of Docker
- - `DISABLE_DELETION_PROTECTION`: Set to `true` to disable deletion protection (ie. ephemeral installations) (default: `false`)
- - `ELASTICACHE_NODE_TYPE`: the ElastiCache [instance type](https://aws.amazon.com/elasticache/pricing/)
- - `MASTER_GUARDDUTY_ACCOUNT_ID`: AWS account id that Cloudtrail events will be sent to
- - `POSTGRES_VERSION`: the version of Postgres to run
- - `RDS_INSTANCE_CLASS`: the RDS [instance type](https://aws.amazon.com/rds/postgresql/pricing/)
- - `SSH_WHITELIST`**:** your current IP address which will allow you SSH into the bastion to debug the Kubernetes cluster
- - `VPC_CIDR_NEWBITS`: Set to a number to configure newbits used to calculate subnets used in `cidrsubnet` function
+- `AWS_SESSION_TOKEN`: the AWS session token for authenticating Terraform
+- `DISABLE_CLOUDTRAIL`: Set to `false` to disable creation of Cloudtrail resources
+- `DISABLE_DOCKER_VERIFICATION`: Set to `false` when running the installer outside of Docker
+- `DISABLE_DELETION_PROTECTION`: Set to `true` to disable deletion protection (ie. ephemeral installations) (default: `false`)
+- `ELASTICACHE_NODE_TYPE`: the ElastiCache [instance type](https://aws.amazon.com/elasticache/pricing/)
+- `MASTER_GUARDDUTY_ACCOUNT_ID`: AWS account id that Cloudtrail events will be sent to
+- `POSTGRES_VERSION`: the version of Postgres to run
+- `RDS_INSTANCE_CLASS`: the RDS [instance type](https://aws.amazon.com/rds/postgresql/pricing/)
+- `SSH_WHITELIST`**:** your current IP address which will allow you SSH into the bastion to debug the Kubernetes cluster
+- `VPC_CIDR_NEWBITS`: Set to a number to configure newbits used to calculate subnets used in `cidrsubnet` function
+- `K8_VERSION`: Version of kubernetes to run. Defaults to `1.25`
 
 ### 5. Deploy the infrastructure.
 
@@ -193,55 +194,56 @@ Configure the environment variables:
 
 **Required**
 
- - `AWS_ACCESS_KEY_ID`: your AWS access key id
- - `AWS_REGION`: the AWS region to deploy resources to
- - `AWS_SECRET_ACCESS_KEY`: your AWS secret access key
- - `DOCKER_EMAIL`: your Docker email
- - `DOCKER_PASSWORD`: your Docker password
- - `DOCKER_USERNAME`: your Docker username
- - `DOMAIN`: your domain name
- - `ORGANIZATION`: the name of your organization (no spaces, all lowercase)
- - `TF_ORGANIZATION`: the name of the organization your Terraform account belongs to
- - `TF_TOKEN`: your Terraform API key
- - `TF_WORKSPACE`: the Terraform workspace for the helm chart. **Make sure this is different than the infra workspace!**
+- `AWS_ACCESS_KEY_ID`: your AWS access key id
+- `AWS_REGION`: the AWS region to deploy resources to
+- `AWS_SECRET_ACCESS_KEY`: your AWS secret access key
+- `DOCKER_EMAIL`: your Docker email
+- `DOCKER_PASSWORD`: your Docker password
+- `DOCKER_USERNAME`: your Docker username
+- `DOMAIN`: your domain name
+- `ORGANIZATION`: the name of your organization (no spaces, all lowercase)
+- `TF_ORGANIZATION`: the name of the organization your Terraform account belongs to
+- `TF_TOKEN`: your Terraform API key
+- `TF_WORKSPACE`: the Terraform workspace for the helm chart. **Make sure this is different than the infra workspace!**
 
 **Required (from infra workspace):**
 
 These variables should be pulled from the `infra` workspace.
 
- - `AWS_WORKSPACE`: retrieve from `workspace` output. Used to configure [resource groups](https://docs.aws.amazon.com/ARG/latest/userguide/resource-groups.html)
- - `CLUSTER_NAME`: retrieve from `cluster_name` output. Name of your EKS cluster.
+- `AWS_WORKSPACE`: retrieve from `workspace` output. Used to configure [resource groups](https://docs.aws.amazon.com/ARG/latest/userguide/resource-groups.html)
+- `CLUSTER_NAME`: retrieve from `cluster_name` output. Name of your EKS cluster.
 
 **Optional**
 
- - `ACM_CERTIFICATE_ARN`: Use to provide your own existing certificate ACM certificate ARN for use with the load balancer
- - `DISABLE_DOCKER_VERIFICATION`: Set to `false` when running the installer outside of Docker
- - `ENVIRONMENT`: used when deploying multiple installations of Paragon. should be left empty or set to `enterprise`
+- `ACM_CERTIFICATE_ARN`: Use to provide your own existing certificate ACM certificate ARN for use with the load balancer
+- `DISABLE_DOCKER_VERIFICATION`: Set to `false` when running the installer outside of Docker
+- `ENVIRONMENT`: used when deploying multiple installations of Paragon. should be left empty or set to `enterprise`
+- `K8_VERSION`: Version of kubernetes to run. Defaults to `1.25`
 
 ### 7. Configure the `.secure/values.yaml` file.
 
 **Required**
 
- - `LICENSE`: your Paragon license
- - `SENDGRID_API_KEY`: your SendGrid API key
- - `SENDGRID_FROM_ADDRESS`: the email to send SendGrid emails from
- - `VERSION`: the version of Paragon you want to run
+- `LICENSE`: your Paragon license
+- `SENDGRID_API_KEY`: your SendGrid API key
+- `SENDGRID_FROM_ADDRESS`: the email to send SendGrid emails from
+- `VERSION`: the version of Paragon you want to run
 
 **Required (from infra workspace)**
 
- - `MINIO_MICROSERVICE_PASS`: from `minio_microservice_pass` output
- - `MINIO_MICROSERVICE_USER`: from `minio_microservice_user` output
- - `MINIO_PUBLIC_BUCKET`: from `minio_public_bucket` output
- - `MINIO_ROOT_PASSWORD`: from `minio_root_password` output
- - `MINIO_ROOT_USER`: from `minio_root_user` output
- - `MINIO_SYSTEM_BUCKET`: from `minio_private_bucket` output
- - `POSTGRES_DATABASE`: from `postgres_database` output
- - `POSTGRES_HOST`: from `postgres_host` output
- - `POSTGRES_PASSWORD`: from `postgres_password` output
- - `POSTGRES_PORT`: from `postgres_port` output
- - `POSTGRES_USER`: from `postgres_user` output
- - `REDIS_HOST`: from `redis_host` output
- - `REDIS_PORT`: from `redis_port` output
+- `MINIO_MICROSERVICE_PASS`: from `minio_microservice_pass` output
+- `MINIO_MICROSERVICE_USER`: from `minio_microservice_user` output
+- `MINIO_PUBLIC_BUCKET`: from `minio_public_bucket` output
+- `MINIO_ROOT_PASSWORD`: from `minio_root_password` output
+- `MINIO_ROOT_USER`: from `minio_root_user` output
+- `MINIO_SYSTEM_BUCKET`: from `minio_private_bucket` output
+- `POSTGRES_DATABASE`: from `postgres_database` output
+- `POSTGRES_HOST`: from `postgres_host` output
+- `POSTGRES_PASSWORD`: from `postgres_password` output
+- `POSTGRES_PORT`: from `postgres_port` output
+- `POSTGRES_USER`: from `postgres_user` output
+- `REDIS_HOST`: from `redis_host` output
+- `REDIS_PORT`: from `redis_port` output
 
 ### 8. Deploy the Helm chart.
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Copy the environment variable files into the `.secure/` directory and remove `.e
 - `SSH_WHITELIST`**:** your current IP address which will allow you SSH into the bastion to debug the Kubernetes cluster
 - `VPC_CIDR_NEWBITS`: Set to a number to configure newbits used to calculate subnets used in `cidrsubnet` function
 - `K8_VERSION`: Version of kubernetes to run. Defaults to `1.25`
+- `EKS_ADDON_EBS_CSI_DRIVER_ENABLED`: Whether or not to disable creating the EKS EBS CSI Driver. Needed for Kubernetes versions >= 1.23
 
 ### 5. Deploy the infrastructure.
 

--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -27,6 +27,15 @@ module "eks" {
       groups   = ["system:masters"]
     }
   ]
+
+  cluster_addons = merge(var.eks_addon_ebs_csi_driver_enabled ? {
+    aws-ebs-csi-driver = {
+      resolve_conflicts = "OVERWRITE"
+    }
+    } : {}
+    , {
+      # additional addons go here
+  })
 }
 
 resource "aws_iam_role" "node_role" {

--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -4,7 +4,7 @@ module "eks" {
   version = "18.24.1"
 
   cluster_name    = var.workspace
-  cluster_version = "1.22"
+  cluster_version = var.k8_version
   subnet_ids      = var.private_subnet.*.id
 
   vpc_id                    = var.vpc.id
@@ -95,7 +95,7 @@ module "eks_node_group" {
   desired_size               = 3  # TODO: decrease desired size
   cluster_name               = var.workspace
   create_before_destroy      = true
-  kubernetes_version         = ["1.22"]
+  kubernetes_version         = [var.k8_version]
   namespace                  = "paragon"
   node_role_arn              = [aws_iam_role.node_role.arn]
   cluster_autoscaler_enabled = true

--- a/terraform/workspaces/infra/cluster/variables.tf
+++ b/terraform/workspaces/infra/cluster/variables.tf
@@ -37,3 +37,8 @@ variable "private_subnet" {
 variable "bastion_role_arn" {
   description = "IAM role arn of bastion instance"
 }
+
+variable "k8_version" {
+  description = "The version of Kubernetes to run in the cluster."
+  type        = string
+}

--- a/terraform/workspaces/infra/cluster/variables.tf
+++ b/terraform/workspaces/infra/cluster/variables.tf
@@ -38,6 +38,12 @@ variable "bastion_role_arn" {
   description = "IAM role arn of bastion instance"
 }
 
+variable "eks_addon_ebs_csi_driver_enabled" {
+  # Should be on for Kubernetes >= 1.23, but optional for backwards compatability for manually migrated installations.
+  description = "Whether or not to enable AWS CSI Driver addon."
+  type        = bool
+}
+
 variable "k8_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string

--- a/terraform/workspaces/infra/modules.tf
+++ b/terraform/workspaces/infra/modules.tf
@@ -92,6 +92,7 @@ module "cluster" {
 
   workspace   = local.workspace
   environment = local.environment
+  k8_version  = var.k8_version
 
   vpc              = module.network.vpc
   public_subnet    = module.network.public_subnet

--- a/terraform/workspaces/infra/modules.tf
+++ b/terraform/workspaces/infra/modules.tf
@@ -90,9 +90,10 @@ module "cluster" {
   aws_region            = var.aws_region
   aws_session_token     = var.aws_session_token
 
-  workspace   = local.workspace
-  environment = local.environment
-  k8_version  = var.k8_version
+  workspace                        = local.workspace
+  environment                      = local.environment
+  k8_version                       = var.k8_version
+  eks_addon_ebs_csi_driver_enabled = var.eks_addon_ebs_csi_driver_enabled
 
   vpc              = module.network.vpc
   public_subnet    = module.network.public_subnet

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -91,6 +91,12 @@ variable "app_bucket_expiration" {
   default     = 365
 }
 
+variable "k8_version" {
+  description = "The version of Kubernetes to run in the cluster."
+  type        = string
+  default     = "1.25"
+}
+
 locals {
   workspace   = "paragon-enterprise-${random_string.app.result}"
   environment = "enterprise"

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -97,6 +97,13 @@ variable "k8_version" {
   default     = "1.25"
 }
 
+variable "eks_addon_ebs_csi_driver_enabled" {
+  # Should be on for Kubernetes >= 1.23, but optional for backwards compatability for manually migrated installations.
+  description = "Whether or not to enable AWS CSI Driver addon."
+  type        = bool
+  default     = true
+}
+
 locals {
   workspace   = "paragon-enterprise-${random_string.app.result}"
   environment = "enterprise"

--- a/terraform/workspaces/paragon/helm/helm.tf
+++ b/terraform/workspaces/paragon/helm/helm.tf
@@ -224,7 +224,7 @@ resource "helm_release" "paragon_on_prem" {
 
   set {
     name  = "global.env.K8_VERSION"
-    value = "1.22"
+    value = var.k8_version
   }
 
   depends_on = [
@@ -358,7 +358,7 @@ resource "helm_release" "paragon_monitoring" {
 
   set {
     name  = "global.env.K8_VERSION"
-    value = "1.22"
+    value = var.k8_version
   }
 
   depends_on = [

--- a/terraform/workspaces/paragon/helm/variables.tf
+++ b/terraform/workspaces/paragon/helm/variables.tf
@@ -83,3 +83,8 @@ variable "ingress_scheme" {
   description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
   type        = string
 }
+
+variable "k8_version" {
+  description = "The version of Kubernetes to run in the cluster."
+  type        = string
+}

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -27,6 +27,7 @@ module "helm" {
   monitors_enabled = var.monitors_enabled
   monitor_version  = local.monitor_version
   ingress_scheme   = var.ingress_scheme
+  k8_version       = var.k8_version
 
   acm_certificate_arn = module.alb.acm_certificate_arn
 }

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -94,6 +94,12 @@ variable "ingress_scheme" {
   default     = "internet-facing"
 }
 
+variable "k8_version" {
+  description = "The version of Kubernetes to run in the cluster."
+  type        = string
+  default     = "1.25"
+}
+
 locals {
   base_helm_values = yamldecode(
     base64decode(var.helm_values),


### PR DESCRIPTION
### Overview
This PR adds the ability to configure the kubernetes version and enabling the [AWS EBS CSI Driver addon](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) which is needed for Kubernetes versions >= 1.23.

EKS ends support for Kubernetes version 1.22 on Sunday, June 4, 2023, which is why we're upgrading the default Kubernetes version.

Existing installations will have to manually add the EBS CSI Driver to prevent zero downtime, but that would break deployments to the `infra` workspace on subsequent deployments because it already exists. Allowing disabling creation of it adds backwards compatibility. 

### Changes
- allow configuring kubernetes version
- change default kubernetes version from `1.22` -> `1.25`