### PR TITLE
Feature/para 8070/rds restore from snapshot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+**/node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ Copy the environment variable files into the `.secure/` directory and remove `.e
 - `MULTI_POSTGRES`: Whether or not to create multiple Postgres instances. Used for high volume installations. (default: `false`)
 - `MULTI_REDIS`: Whether or not to create multiple Redis instances. Used for high volume installations. (default: `false`)
 - `POSTGRES_VERSION`: the version of Postgres to run
+- `RDS_FINAL_SNAPSHOT_ENABLED`: Specifies that RDS should take a final snapshot (default: `true`)
 - `RDS_INSTANCE_CLASS`: the RDS [instance type](https://aws.amazon.com/rds/postgresql/pricing/) (default: `db.t3.small`)
+- `RDS_RESTORE_FROM_SNAPSHOT`: Specifies that RDS instance(s) should be restored from snapshots (default: `false`)
 - `SSH_WHITELIST`: your current IP address which will allow you SSH into the bastion to debug the Kubernetes cluster
 - `VPC_CIDR_NEWBITS`: Set to a number to configure newbits used to calculate subnets used in `cidrsubnet` function
 

--- a/terraform/workspaces/infra/modules.tf
+++ b/terraform/workspaces/infra/modules.tf
@@ -41,6 +41,8 @@ module "postgres" {
   environment                 = local.environment
   postgres_version            = var.postgres_version
   rds_instance_class          = var.rds_instance_class
+  rds_restore_from_snapshot   = var.rds_restore_from_snapshot
+  rds_final_snapshot_enabled  = var.rds_final_snapshot_enabled
   disable_deletion_protection = var.disable_deletion_protection
   multi_az_enabled            = var.multi_az_enabled
   multi_postgres              = var.multi_postgres

--- a/terraform/workspaces/infra/postgres/rds.tf
+++ b/terraform/workspaces/infra/postgres/rds.tf
@@ -91,7 +91,7 @@ resource "aws_db_instance" "postgres" {
   allocated_storage           = 20
   max_allocated_storage       = 1000
   allow_major_version_upgrade = false
-  auto_minor_version_upgrade  = true
+  auto_minor_version_upgrade  = false
   availability_zone           = var.multi_az_enabled ? null : var.availability_zones.names[0]
   backup_retention_period     = 7
   monitoring_interval         = 15

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -59,7 +59,7 @@ variable "rds_restore_from_snapshot" {
 }
 
 variable "rds_final_snapshot_enabled" {
-  description = "Specifies that RDS instances should be restored from a snapshot."
+  description = "Specifies that RDS instances should perform a final snapshot before being deleted."
   type        = bool
 }
 

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -53,6 +53,16 @@ variable "rds_instance_class" {
   description = "The RDS instance class type used for Postgres."
 }
 
+variable "rds_restore_from_snapshot" {
+  description = "Specifies that RDS instances should be restored from a snapshot."
+  type        = bool
+}
+
+variable "rds_final_snapshot_enabled" {
+  description = "Specifies that RDS instances should be restored from a snapshot."
+  type        = bool
+}
+
 variable "disable_deletion_protection" {
   description = "Whether to disable deletion protection."
   type        = bool

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -49,6 +49,18 @@ variable "rds_instance_class" {
   default     = "db.t3.small"
 }
 
+variable "rds_restore_from_snapshot" {
+  description = "Specifies that RDS instances should be restored from a snapshot."
+  type        = bool
+  default     = false
+}
+
+variable "rds_final_snapshot_enabled" {
+  description = "Specifies that RDS instances should be restored from a snapshot."
+  type        = bool
+  default     = true
+}
+
 variable "elasticache_node_type" {
   description = "The ElastiCache node type used for Redis."
   type        = string

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -56,7 +56,7 @@ variable "rds_restore_from_snapshot" {
 }
 
 variable "rds_final_snapshot_enabled" {
-  description = "Specifies that RDS instances should be restored from a snapshot."
+  description = "Specifies that RDS instances should perform a final snapshot before being deleted."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
### Issues Closed

- PARA-8070

### Overview

This PR provides options for working with snapshots. When doing load testing or working with other ephemeral environments, we don't always want to create our data from scratch. With these changes, we can take down environments (to save costs) and restore them later from snapshots (to save time).

### Changes

- added `RDS_FINAL_SNAPSHOT_ENABLED` boolean option to `infra` workspace
- added `RDS_RESTORE_FROM_SNAPSHOT` boolean option to `infra` workspace
- added datasources to fetch existing snapshots when `RDS_RESTORE_FROM_SNAPSHOT` enabled
- updated README with instructions for options

### Unrelated Changes

- added `.dockerignore` file (reduced `make build` command execution time from over a minute to about 1 second)