### PR TITLE
Fix RDS restore from snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ These variables should be pulled from the `infra` workspace.
 **Optional**
 
 - `ACM_CERTIFICATE_ARN`: Use to provide your own existing certificate ACM certificate ARN for use with the load balancer
+- `CLOUDFLARE_DNS_API_TOKEN`: Cloudflare api token to use when updating nameservers.
+- `CLOUDFLARE_ZONE_ID`: Cloudflare zone id to use when updating nameservers.
 - `DISABLE_DOCKER_VERIFICATION`: Set to `false` when running the installer outside of Docker
+- `DNS_PROVIDER`: specifies which DNS provider to update nameservers. Currently only supports `cloudflare`
 - `ENVIRONMENT`: used when deploying multiple installations of Paragon. should be left empty or set to `enterprise`
 - `K8_VERSION`: Version of kubernetes to run. Defaults to `1.25`
 

--- a/terraform/templates/main.tpl.tf
+++ b/terraform/templates/main.tpl.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.67.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
   }
 
   backend "remote" {

--- a/terraform/workspaces/infra/postgres/outputs.tf
+++ b/terraform/workspaces/infra/postgres/outputs.tf
@@ -4,8 +4,8 @@ output "rds" {
     key => {
       host     = aws_db_instance.postgres[key].address
       port     = aws_db_instance.postgres[key].port
-      user     = random_string.postgres_root_username[key].result
-      password = random_string.postgres_root_password[key].result
+      user     = aws_db_instance.postgres[key].username
+      password = var.rds_restore_from_snapshot ? null : random_string.postgres_root_password[key].result
       database = aws_db_instance.postgres[key].name
     }
   }

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -97,7 +97,7 @@ locals {
     }
     zeus = {
       name = "${var.workspace}-zeus"
-      size = var.rds_instance_class
+      size = "db.t4g.small"
       db   = "zeus"
     }
     } : {

--- a/terraform/workspaces/paragon/.terraform.lock.hcl
+++ b/terraform/workspaces/paragon/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "3.35.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:SFvdgX5bTGhOTMhywgjSOWlkET2el7STxdUSzxjz2pc=",
+    "zh:13aabc00fee823422831bcc870227650cc765fc4c9622074d24d6d62a4ac0e37",
+    "zh:1544405f0ea6b388dad7eb25c434427b2682417396da9186e1b33551e6b4adff",
+    "zh:5d58394cb8e71bd4bf6ef0135f1ca6a4ad2cec937f3731b224125eb34ee059f7",
+    "zh:648596ed545ed01ae757d5a0b37c20e8050cfb51d42e9a2c82fcc94d883ff11d",
+    "zh:68d75e14eef4f073faa975ed6baf4db7e0e1f2fc61a4e54fd95325df42793810",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9916cc626fef57428c4c60db7897b34068c65639b68482e94f62d97d773d64bc",
+    "zh:9c8c9f369eb30e7360a0ebd7918e4846ca4d5bca430b861fdbde7522a3146459",
+    "zh:a40e244688bbcb6f1a771e6ea89fb0b0b7bb53be3fab718abc66b3593e0f8133",
+    "zh:cc5a6191aa8713275550ff2b6adda6e6d56e4780c9cbe3d1da1dc23ea893bfff",
+    "zh:d1dd435780e8c7e79bff26b46a76df0e123971849355ad17877d1e24dc5953c3",
+    "zh:d751fc72f2833f2bdb897fa89de2bb5b6efbad1e648896642f0e6fe5cde789c8",
+    "zh:dfc4c90b3605ec1bb7cc7a9f1fb1b67235578bdd6b9be78e7b3516b55d0422db",
+    "zh:e6101a80fe24e2df3ab60152458ff1666a4a1befc87c62e459a219cdbb53e6df",
+    "zh:e9bcf26c44dd231f74703b6a6717470021a3ba7e1d7531dcf7287a6441300e27",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 3.0.0, ~> 4.67.0"

--- a/terraform/workspaces/paragon/alb/dns.tf
+++ b/terraform/workspaces/paragon/alb/dns.tf
@@ -29,3 +29,14 @@ resource "aws_route53_record" "microservice" {
   ttl     = 300
   records = [data.aws_lb.load_balancer.dns_name]
 }
+
+# adding the dns record entry to cloudfare if creds exist
+resource "cloudflare_record" "nameserver" {
+  count = local.has_cloudflare_credentials ? length(aws_route53_zone.paragon.name_servers) : 0
+
+  name    = var.domain
+  zone_id = var.cloudflare_zone_id
+  value   = aws_route53_zone.paragon.name_servers[count.index]
+  type    = "NS"
+  ttl     = 60 # TODO: increase the TTL to `600` (10 MINUTES) when stable
+}

--- a/terraform/workspaces/paragon/alb/providers.tf
+++ b/terraform/workspaces/paragon/alb/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_dns_api_token != null ? var.cloudflare_dns_api_token : "placeholder_0apiTokencloudflareonprem100"
+}

--- a/terraform/workspaces/paragon/alb/variables.tf
+++ b/terraform/workspaces/paragon/alb/variables.tf
@@ -37,3 +37,23 @@ variable "release_ingress" {
 variable "release_paragon_on_prem" {
   description = "The helm release for the Paragon microservices."
 }
+
+variable "dns_provider" {
+  description = "DNS provider to use."
+  type        = string
+  default     = "cloudflare"
+}
+
+variable "cloudflare_dns_api_token" {
+  description = "Cloudflare DNS API token for SSL certificate creation and verification."
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone id to set CNAMEs."
+  type        = string
+}
+
+locals {
+  has_cloudflare_credentials = var.dns_provider == "cloudflare" && var.cloudflare_dns_api_token != null && var.cloudflare_zone_id != null
+}

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -1,11 +1,14 @@
 module "alb" {
   source = "./alb"
 
-  acm_certificate_arn = var.acm_certificate_arn
-  aws_workspace       = var.aws_workspace
-  domain              = var.domain
-  microservices       = local.microservices
-  public_monitors     = local.public_monitors
+  acm_certificate_arn      = var.acm_certificate_arn
+  aws_workspace            = var.aws_workspace
+  domain                   = var.domain
+  microservices            = local.microservices
+  public_monitors          = local.public_monitors
+  dns_provider             = var.dns_provider
+  cloudflare_dns_api_token = var.cloudflare_dns_api_token
+  cloudflare_zone_id       = var.cloudflare_zone_id
 
   release_ingress         = module.helm.release_ingress
   release_paragon_on_prem = module.helm.release_paragon_on_prem

--- a/terraform/workspaces/paragon/providers.tf
+++ b/terraform/workspaces/paragon/providers.tf
@@ -12,3 +12,7 @@ provider "aws" {
     }
   }
 }
+
+provider "cloudflare" {
+  api_token = var.cloudflare_dns_api_token
+}

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -117,6 +117,29 @@ variable "k8_version" {
   default     = "1.25"
 }
 
+variable "dns_provider" {
+  description = "DNS provider to use."
+  type        = string
+  default     = "cloudflare"
+
+  validation {
+    condition     = var.dns_provider == "cloudflare" || var.dns_provider == "namecheap"
+    error_message = "Only cloudflare and namecheap are currently supported."
+  }
+}
+
+variable "cloudflare_dns_api_token" {
+  description = "Cloudflare DNS API token for SSL certificate creation and verification."
+  type        = string
+  default     = null
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone id to set CNAMEs."
+  type        = string
+  default     = null
+}
+
 locals {
   raw_helm_env = jsondecode(base64decode(var.helm_env))
   raw_helm_values = try(yamldecode(


### PR DESCRIPTION
### Issues Closed

- PARA-8070

### Overview

This PR is a follow-on to https://github.com/useparagon/aws-on-prem/pull/16. I found a few issues over the weekend where databases restored from snapshots had issues saving or being restored from snapshots.

1. On subsequent Terraform runs, databases created from snapshots were destroyed and recreated because the `aws_db_snapshot` datasource updated with a more recent automated snapshot.
2. Databases restored from snapshots were destroyed and recreated because the `random_string` resources for creating the postgres usernames and password would change. The [Terraform docs](https://registry.terraform.io/providers/-/aws/4.52.0/docs/resources/db_instance) for the `aws_db_instance` resource show specify that `username` and `password` are optional when restoring from a snapshot.
3. Databases restored from a snapshot couldn't be deleted when taking down the environment because the previous snapshot name was taken when both `RDS_FINAL_SNAPSHOT_ENABLED` and `RDS_RESTORE_FROM_SNAPSHOT` enabled

### Changes

- don't create `random_string` resources for postgres username and password when restoring from snapshot
- don't specify `username` and `password` for databases when restoring from snapshot
- create a `random_string` resource as a suffix for the final snapshot identifier to fix destroying databases created from snapshots when both `RDS_FINAL_SNAPSHOT_ENABLED` and `RDS_RESTORE_FROM_SNAPSHOT` enabled
- only restore databases from manually created snapshots

### Unrelated Changes

- dns > added optional Cloudflare variables to `.env-tf-paragon` to update nameservers
- rds > set a db instance size of `db.t4g.small` for Zeus instances created when `MULTI_POSTGRES` is enabled
- rds > get instance class from dynamic `local.postgres_instances` variable