### PR TITLE
Hermes RDS Config + S3 Expiration

### DIFF
--- a/terraform/workspaces/infra/postgres/rds.tf
+++ b/terraform/workspaces/infra/postgres/rds.tf
@@ -108,11 +108,12 @@ resource "aws_db_instance" "postgres" {
   engine_version       = var.postgres_version
   instance_class       = each.value.size
   parameter_group_name = aws_db_parameter_group.postgres.name
-  storage_type         = "gp2"
+  storage_type         = each.value.storage_type
   replicate_source_db  = null
 
   allocated_storage           = 20
   max_allocated_storage       = 1000
+  iops                        = try(each.value.iops, null)
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = false
   availability_zone           = var.multi_az_enabled ? null : var.availability_zones.names[0]

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -81,30 +81,36 @@ variable "multi_postgres" {
 locals {
   postgres_instances = var.multi_postgres ? {
     beethoven = {
-      name = "${var.workspace}-beethoven"
-      size = var.rds_instance_class
-      db   = "beethoven"
+      name         = "${var.workspace}-beethoven"
+      size         = var.rds_instance_class
+      db           = "beethoven"
+      storage_type = "gp2"
     }
     cerberus = {
-      name = "${var.workspace}-cerberus"
-      size = "db.t4g.micro"
-      db   = "cerberus"
+      name         = "${var.workspace}-cerberus"
+      size         = "db.t4g.micro"
+      db           = "cerberus"
+      storage_type = "gp2"
     }
     hermes = {
-      name = "${var.workspace}-hermes"
-      size = var.rds_instance_class
-      db   = "hermes"
+      name         = "${var.workspace}-hermes"
+      size         = var.rds_instance_class
+      db           = "hermes"
+      storage_type = "gp3"
+      iops         = 3000
     }
     zeus = {
-      name = "${var.workspace}-zeus"
-      size = "db.t4g.small"
-      db   = "zeus"
+      name         = "${var.workspace}-zeus"
+      size         = "db.t4g.small"
+      db           = "zeus"
+      storage_type = "gp2"
     }
     } : {
     paragon = {
-      name = "${var.workspace}"
-      size = var.rds_instance_class
-      db   = "postgres"
+      name         = "${var.workspace}"
+      size         = var.rds_instance_class
+      db           = "postgres"
+      storage_type = "gp2"
     }
   }
 }

--- a/terraform/workspaces/infra/s3/s3-app.tf
+++ b/terraform/workspaces/infra/s3/s3-app.tf
@@ -43,6 +43,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "expiration" {
       days = var.app_bucket_expiration
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.app_bucket_expiration
+    }
+
     status = "Enabled"
   }
 }


### PR DESCRIPTION
### Overview
This PR has some cost savings + RDS performance changes.

**RDS**
This changes the `hermes` database from `gp2` to `gp3` config with 3000 provisioned IOPs. This is better for high volume installations because `hermes` usually has consistent traffic as opposed to burstable.

**S3**
This PR applies the expiration policy to non-current versions for the system bucket.