### PR TITLE
generate env vars for worker variables

### DIFF
--- a/terraform/workspaces/paragon/helm/helm.tf
+++ b/terraform/workspaces/paragon/helm/helm.tf
@@ -106,6 +106,11 @@ resource "helm_release" "ingress" {
     name  = "clusterName"
     value = var.cluster_name
   }
+
+  set {
+    name  = "replicaCount"
+    value = "5"
+  }
 }
 
 # metrics server for hpa

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -340,6 +340,14 @@ locals {
           PLATO_PUBLIC_URL     = try(local.microservices.plato.public_url, null)
           ZEUS_PUBLIC_URL      = try(local.microservices.zeus.public_url, null)
 
+          WORKER_ACTIONS_PUBLIC_URL     = try(local.microservices["worker-actions"].public_url, null)
+          WORKER_CREDENTIALS_PUBLIC_URL = try(local.microservices["worker-credentials"].public_url, null)
+          WORKER_CRONS_PUBLIC_URL       = try(local.microservices["worker-crons"].public_url, null)
+          WORKER_DEPLOYMENTS_PUBLIC_URL = try(local.microservices["worker-deployments"].public_url, null)
+          WORKER_PROXY_PUBLIC_URL       = try(local.microservices["worker-proxy"].public_url, null)
+          WORKER_TRIGGERS_PUBLIC_URL    = try(local.microservices["worker-triggers"].public_url, null)
+          WORKER_WORKFLOWS_PUBLIC_URL   = try(local.microservices["worker-workflows"].public_url, null)
+
           MONITOR_GRAFANA_SLACK_CANARY_CHANNEL          = "<PLACEHOLDER>"
           MONITOR_GRAFANA_SLACK_CANARY_BETA_CHANNEL     = "<PLACEHOLDER>"
           MONITOR_GRAFANA_SLACK_CANARY_WEBHOOK_URL      = "<PLACEHOLDER>"


### PR DESCRIPTION
### Overview

This PR generates the public urls for the workers to be used as environment variables within the microservices. This is needed for recent changes that went in in which requests are made to `worker-proxy` via the public internet.

### Unrelated Changes

Additionally this PR increases the replica count for the application load balancer pods from the default `2` to `5`.