### PR TITLE
fix(infra): removed aws_iam_policy_attachment usage

### DIFF
--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -185,9 +185,9 @@ module "eks_managed_node_group" {
   depends_on = [
     module.eks,
     aws_iam_role.node_role,
-    aws_iam_policy_attachment.custom_worker_policy_attachment,
-    aws_iam_policy_attachment.AmazonEKSWorkerNodePolicy,
-    aws_iam_policy_attachment.AmazonEC2ContainerRegistryReadOnly,
-    aws_iam_policy_attachment.AmazonEKS_CNI_Policy
+    aws_iam_role_policy_attachment.custom_worker_policy_attachment,
+    aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy
   ]
 }

--- a/terraform/workspaces/infra/cluster/security.tf
+++ b/terraform/workspaces/infra/cluster/security.tf
@@ -52,27 +52,23 @@ resource "aws_iam_policy" "eks_worker_policy" {
   }
 }
 
-resource "aws_iam_policy_attachment" "custom_worker_policy_attachment" {
-  name       = "${var.workspace}-custom-worker-policy"
-  roles      = [aws_iam_role.node_role.name]
+resource "aws_iam_role_policy_attachment" "custom_worker_policy_attachment" {
+  role       = aws_iam_role.node_role.name
   policy_arn = aws_iam_policy.eks_worker_policy.arn
 }
 
-resource "aws_iam_policy_attachment" "AmazonEKSWorkerNodePolicy" {
-  name       = "${var.workspace}-eks-worker-node-policy"
-  roles      = [aws_iam_role.node_role.name]
+resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy" {
+  role       = aws_iam_role.node_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
 }
 
-resource "aws_iam_policy_attachment" "AmazonEC2ContainerRegistryReadOnly" {
-  name       = "${var.workspace}-ec2-container-registry-policy"
-  roles      = [aws_iam_role.node_role.name]
+resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly" {
+  role       = aws_iam_role.node_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
-resource "aws_iam_policy_attachment" "AmazonEKS_CNI_Policy" {
-  name       = "${var.workspace}-eks-cni-policy"
-  roles      = [aws_iam_role.node_role.name]
+resource "aws_iam_role_policy_attachment" "AmazonEKS_CNI_Policy" {
+  role       = aws_iam_role.node_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
 }
 


### PR DESCRIPTION
### Brief Summary

Replaces exclusive `aws_iam_policy_attachment` usage with `aws_iam_role_policy_attachment`.

### Detailed Summary

The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. Using aws_iam_role_policy_attachment allows Paragon roles to attach policies without affecting other roles.

### Changes

- replace `aws_iam_policy_attachment` with `aws_iam_role_policy_attachment`

### Steps to Test

- perform a Terraform apply and ensure that other roles that have any of the following policies don't have them revoked.
  - AmazonEC2ContainerRegistryReadOnly
  - AmazonEKS_CNI_Policy
  - AmazonEKSWorkerNodePolicy
