### PR TITLE
Remove beethoven exporter

### DIFF
--- a/terraform/workspaces/infra/.terraform.lock.hcl
+++ b/terraform/workspaces/infra/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "3.35.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:SFvdgX5bTGhOTMhywgjSOWlkET2el7STxdUSzxjz2pc=",
+    "zh:13aabc00fee823422831bcc870227650cc765fc4c9622074d24d6d62a4ac0e37",
+    "zh:1544405f0ea6b388dad7eb25c434427b2682417396da9186e1b33551e6b4adff",
+    "zh:5d58394cb8e71bd4bf6ef0135f1ca6a4ad2cec937f3731b224125eb34ee059f7",
+    "zh:648596ed545ed01ae757d5a0b37c20e8050cfb51d42e9a2c82fcc94d883ff11d",
+    "zh:68d75e14eef4f073faa975ed6baf4db7e0e1f2fc61a4e54fd95325df42793810",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9916cc626fef57428c4c60db7897b34068c65639b68482e94f62d97d773d64bc",
+    "zh:9c8c9f369eb30e7360a0ebd7918e4846ca4d5bca430b861fdbde7522a3146459",
+    "zh:a40e244688bbcb6f1a771e6ea89fb0b0b7bb53be3fab718abc66b3593e0f8133",
+    "zh:cc5a6191aa8713275550ff2b6adda6e6d56e4780c9cbe3d1da1dc23ea893bfff",
+    "zh:d1dd435780e8c7e79bff26b46a76df0e123971849355ad17877d1e24dc5953c3",
+    "zh:d751fc72f2833f2bdb897fa89de2bb5b6efbad1e648896642f0e6fe5cde789c8",
+    "zh:dfc4c90b3605ec1bb7cc7a9f1fb1b67235578bdd6b9be78e7b3516b55d0422db",
+    "zh:e6101a80fe24e2df3ab60152458ff1666a4a1befc87c62e459a219cdbb53e6df",
+    "zh:e9bcf26c44dd231f74703b6a6717470021a3ba7e1d7531dcf7287a6441300e27",
+  ]
+}
+
 provider "registry.terraform.io/cloudposse/utils" {
   version     = "1.8.0"
   constraints = ">= 0.17.0"

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -97,7 +97,7 @@ locals {
       size         = var.rds_instance_class
       db           = "hermes"
       storage_type = "gp3"
-      iops         = 3000
+      iops         = !contains(["db.t4g.micro", "db.t4g.small", "db.t3.micro", "db.t3.small"], var.rds_instance_class) ? 3000 : null
     }
     zeus = {
       name         = "${var.workspace}-zeus"

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -262,10 +262,6 @@ locals {
   }
 
   monitors = {
-    "beethoven-exporter" = {
-      "port"       = 8002
-      "public_url" = null
-    }
     "bull-exporter" = {
       "port"       = 9538
       "public_url" = null
@@ -466,8 +462,6 @@ locals {
             WORKER_TRIGGERS_PRIVATE_URL    = try("http://worker-triggers:${local.microservices["worker-triggers"].port}", null)
             WORKER_WORKFLOWS_PRIVATE_URL   = try("http://worker-workflows:${local.microservices["worker-workflows"].port}", null)
 
-            MONITOR_BEETHOVEN_EXPORTER_HOST         = "http://beethoven-exporter"
-            MONITOR_BEETHOVEN_EXPORTER_PORT         = try(local.monitors["beethoven-exporter"].port, null)
             MONITOR_BULL_EXPORTER_HOST              = "http://bull-exporter"
             MONITOR_BULL_EXPORTER_PORT              = try(local.monitors["bull-exporter"].port, null)
             MONITOR_GRAFANA_AWS_ACCESS_ID           = var.monitors_enabled ? module.monitors[0].grafana_aws_access_key_id : null


### PR DESCRIPTION
### Overview

This PR removes `beethoven-exporter` from the monitors, which was removed in v2.88.2.

### Changes

- remove `beethoven-exporter` from monitors

### Unrelated Changes

- fix postgres IOPS config for small RDS instances
- updated Terraform dependencies