### PR TITLE
fix(infra): add explicit tunnel subdomain variable

### DIFF
--- a/terraform/workspaces/infra/bastion/variables.tf
+++ b/terraform/workspaces/infra/bastion/variables.tf
@@ -53,6 +53,12 @@ variable "cloudflare_tunnel_enabled" {
   default     = false
 }
 
+variable "cloudflare_tunnel_subdomain" {
+  description = "Subdomain under the Cloudflare Zone to create the tunnel"
+  type        = string
+  default     = ""
+}
+
 variable "cloudflare_tunnel_zone_id" {
   description = "Zone ID for Cloudflare domain"
   type        = string

--- a/terraform/workspaces/infra/modules.tf
+++ b/terraform/workspaces/infra/modules.tf
@@ -135,6 +135,7 @@ module "bastion" {
 
   cloudflare_api_token           = var.cloudflare_api_token
   cloudflare_tunnel_enabled      = var.cloudflare_tunnel_enabled
+  cloudflare_tunnel_subdomain    = var.cloudflare_tunnel_subdomain
   cloudflare_tunnel_zone_id      = var.cloudflare_tunnel_zone_id
   cloudflare_tunnel_account_id   = var.cloudflare_tunnel_account_id
   cloudflare_tunnel_email_domain = var.cloudflare_tunnel_email_domain

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -202,6 +202,12 @@ variable "cloudflare_tunnel_enabled" {
   default     = false
 }
 
+variable "cloudflare_tunnel_subdomain" {
+  description = "Subdomain under the Cloudflare Zone to create the tunnel"
+  type        = string
+  default     = ""
+}
+
 variable "cloudflare_tunnel_zone_id" {
   description = "Zone ID for Cloudflare domain"
   type        = string


### PR DESCRIPTION
### Issues Closed

- PARA-9734

### Brief Summary

Adds explicit Cloudflare Tunnel subdomain variable to avoid potential conflicts.

### Detailed Summary

The subdomain of the Cloudflare Zero Trust tunnel was being derived from the `app_name` or `organization`. This could lead to conflicts across customer environments if those weren't set. This also allows setting/changing the tunnel domain without having to recreate countless other resources that share the same name variables.

### Changes

- added new `cloudflare_tunnel_subdomain` variable for setting tunnel domain

### Unrelated Changes

none

### Future Work

- consolidate `on-prem` and `aws-on-prem` so this work doesn't have to be duplicated across repos

### Steps to Test

- deploy with tunnel settings all set and ensure that domain in Cloudflare matches values
- deploy with tunnel enabled but without setting `cloudflare_tunnel_subdomain` and ensure that Terraform fails with the message below

### QA Notes

none

### Deployment Notes

- the `cloudflare_tunnel_subdomain` will have to be set and unique for each on-prem environment using tunnels

### Screenshots

![image](https://github.com/useparagon/on-prem/assets/114427170/0b11ccc6-f357-4d1b-9da7-57072857e83e)
