### PR TITLE
fix infra outputs when restoring from snapshots

### DIFF
--- a/terraform/workspaces/infra/outputs.tf
+++ b/terraform/workspaces/infra/outputs.tf
@@ -97,7 +97,7 @@ output "paragon_config" {
     POSTGRES_HOST: ${local.db_info.host}
     POSTGRES_PORT: ${local.db_info.port}
     POSTGRES_USER: ${local.db_info.user}
-    POSTGRES_PASSWORD: ${local.db_info.password}
+    POSTGRES_PASSWORD: ${local.db_info.password == null ? "" : local.db_info.password}
     POSTGRES_DATABASE: ${local.db_info.database}
 
     REDIS_HOST: ${module.redis.elasticache.cache.host}

--- a/terraform/workspaces/infra/s3/s3-app.tf
+++ b/terraform/workspaces/infra/s3/s3-app.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "app" {
   }
 
   versioning {
-    enabled = true
+    enabled = var.force_destroy ? false : true
   }
 
   server_side_encryption_configuration {

--- a/terraform/workspaces/paragon/monitors/grafana.tf
+++ b/terraform/workspaces/paragon/monitors/grafana.tf
@@ -57,7 +57,7 @@ resource "random_string" "grafana_admin_email_prefix" {
   special = false
   numeric = false
   lower   = true
-  upper   = true
+  upper   = false
 }
 
 resource "random_string" "grafana_admin_password" {

--- a/terraform/workspaces/paragon/monitors/pgadmin.tf
+++ b/terraform/workspaces/paragon/monitors/pgadmin.tf
@@ -18,5 +18,5 @@ resource "random_string" "pgadmin_admin_password" {
   numeric     = true
   special     = false
   lower       = true
-  upper       = true
+  upper       = false
 }

--- a/terraform/workspaces/paragon/monitors/pgadmin.tf
+++ b/terraform/workspaces/paragon/monitors/pgadmin.tf
@@ -5,7 +5,7 @@ resource "random_string" "pgadmin_admin_email_prefix" {
   special = false
   numeric = false
   lower   = true
-  upper   = true
+  upper   = false
 }
 
 resource "random_string" "pgadmin_admin_password" {
@@ -18,5 +18,5 @@ resource "random_string" "pgadmin_admin_password" {
   numeric     = true
   special     = false
   lower       = true
-  upper       = false
+  upper       = true
 }


### PR DESCRIPTION
### Overview

This PR fixes the outputs in the infra workspace when restoring the RDS database from a snapshot (`RDS_RESTORE_FROM_SNAPSHOT=true`). Null values aren't allowed in string interpolations.

This use case is primarily used when spinning up + down ephemeral environments when load testing.

### Unrelated Changes

- disable bucket versioning when `DISABLE_DELETION_PROTECTION=true`, which makes it harder + take longer to delete buckets
- only allow lowercase characters when generating Grafana and PGAdmin emails