### PR TITLE
feat(monitor): added betterstack uptime checks

### DIFF
--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -136,7 +136,7 @@ variable "multi_redis" {
 variable "k8_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
-  default     = "1.25"
+  default     = "1.28"
 }
 
 variable "k8_ondemand_node_instance_type" {

--- a/terraform/workspaces/paragon/.terraform.lock.hcl
+++ b/terraform/workspaces/paragon/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/betterstackhq/better-uptime" {
+  version = "0.6.1"
+  hashes = [
+    "h1:PoYW4p9l/O0H0NbN/kqNG51cCcyRVaO5gPnLXiAl+Ds=",
+    "zh:0281d80170429bd39cd7c3e431b7b45dddf1be22b703e2ea6dc534ffc9f70f7f",
+    "zh:1666632f0a8ef1c018ef85ee52e8434c2343479a82312e626b51c9d616de8654",
+    "zh:2a9c2d6bdc474b4de372474d069393236e90bbca170dee7bb4f173364f97a27c",
+    "zh:4986d8f037087710be8f9e7bb9ebe4c0e1eb92e43d9b7c3463372f5519f37416",
+    "zh:4a951373b6444a66b35bb926c161c7012abbdc1fb047cfb5f8dabf2d9a2cb2df",
+    "zh:55c65ad9458cdd1b7436c16dc6815e835e52910cdb4d215227af67c197498a27",
+    "zh:64910c4fab486fcb18e66a6a7bfe6d0aac07308bc4627a3564e3027d097b3a5a",
+    "zh:6e4fafedb85e7746dbf69cb9fa9b59d3387b4c7a42c02af5a06b211e62a5703c",
+    "zh:7227c932e03773c584671895526c97c452273af9a23e7a0818a12e8c0c5c2aa0",
+    "zh:7c3a231eefb99a745b4283d587250d32392916f2076ac37eb319a0b919350238",
+    "zh:873f080b624722402c57772b0a9c0f2e95da9573748c8e0444b24373bb27764e",
+    "zh:eb796ada75cb8f16f1ed8ee7d2b0c7c06abb4b710d21c5ab887d24c9dcf0ede5",
+    "zh:f2084a227c9dde8ced0ca0c7f02548b5055a16570fc2f324593ce3cff98f9b55",
+  ]
+}
+
 provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "4.22.0"
   constraints = "~> 4.0"

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -49,3 +49,11 @@ module "monitors" {
   pgadmin_admin_email           = try(local.base_helm_values.global.env["MONITOR_PGADMIN_EMAIL"], null)
   pgadmin_admin_password        = try(local.base_helm_values.global.env["MONITOR_PGADMIN_PASSWORD"], null)
 }
+
+module "uptime" {
+  source = "./uptime"
+
+  uptime_api_token = var.uptime_api_token
+  uptime_company   = coalesce(var.uptime_company, var.organization)
+  microservices    = local.microservices
+}

--- a/terraform/workspaces/paragon/uptime/monitors.tf
+++ b/terraform/workspaces/paragon/uptime/monitors.tf
@@ -1,0 +1,29 @@
+resource "betteruptime_monitor_group" "group" {
+  count = local.enabled ? 1 : 0
+
+  name = var.uptime_company
+}
+
+resource "betteruptime_monitor" "monitor" {
+  for_each = local.enabled ? var.microservices : {}
+
+  pronounceable_name = "Enterprise ${var.uptime_company} - Microservice ${each.key}"
+
+  check_frequency       = 30  # seconds
+  confirmation_period   = 120 # seconds
+  domain_expiration     = 14  # days
+  expected_status_codes = [200]
+  maintenance_timezone  = "Pacific Time (US & Canada)"
+  monitor_group_id      = betteruptime_monitor_group.group[0].id
+  monitor_type          = "expected_status_code"
+  recovery_period       = 60  # seconds
+  request_timeout       = 15  # seconds
+  ssl_expiration        = 14  # days
+  team_wait             = 180 # seconds
+  url                   = "${each.value.public_url}${each.value.healthcheck_path}"
+
+  call  = true
+  email = true
+  push  = true
+  sms   = true
+}

--- a/terraform/workspaces/paragon/uptime/outputs.tf
+++ b/terraform/workspaces/paragon/uptime/outputs.tf
@@ -1,0 +1,4 @@
+output "webhook" {
+  value     = local.enabled ? betteruptime_grafana_integration.webhook[0].webhook_url : ""
+  sensitive = true
+}

--- a/terraform/workspaces/paragon/uptime/provider.tf
+++ b/terraform/workspaces/paragon/uptime/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    betteruptime = {
+      source = "BetterStackHQ/better-uptime"
+    }
+  }
+}
+
+provider "betteruptime" {
+  api_token = coalesce(var.uptime_api_token, "dummy-token")
+}

--- a/terraform/workspaces/paragon/uptime/variables.tf
+++ b/terraform/workspaces/paragon/uptime/variables.tf
@@ -1,0 +1,19 @@
+variable "uptime_api_token" {
+  description = "API Token for setting up BetterStack Uptime monitors."
+  type        = string
+  default     = null
+}
+
+variable "uptime_company" {
+  description = "The pretty company name to include in BetterStack Uptime monitors."
+  type        = string
+}
+
+variable "microservices" {
+  description = "The microservices to create monitors for."
+  type        = map(any)
+}
+
+locals {
+  enabled = var.uptime_api_token != null
+}

--- a/terraform/workspaces/paragon/uptime/webhook.tf
+++ b/terraform/workspaces/paragon/uptime/webhook.tf
@@ -1,0 +1,13 @@
+resource "betteruptime_grafana_integration" "webhook" {
+  count = local.enabled ? 1 : 0
+
+  name = "Enterprise ${var.uptime_company}"
+
+  call  = true
+  email = true
+  push  = true
+  sms   = true
+
+  recovery_period = 0
+  team_wait       = 300
+}

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -140,6 +140,18 @@ variable "cloudflare_zone_id" {
   default     = null
 }
 
+variable "uptime_api_token" {
+  description = "Optional API Token for setting up BetterStack Uptime monitors."
+  type        = string
+  default     = null
+}
+
+variable "uptime_company" {
+  description = "Optional pretty company name to include in BetterStack Uptime monitors."
+  type        = string
+  default     = null
+}
+
 locals {
   raw_helm_env = jsondecode(base64decode(var.helm_env))
   raw_helm_values = try(yamldecode(
@@ -471,6 +483,7 @@ locals {
             MONITOR_GRAFANA_SECURITY_ADMIN_PASSWORD = var.monitors_enabled ? module.monitors[0].grafana_admin_password : null
             MONITOR_GRAFANA_HOST                    = "http://grafana"
             MONITOR_GRAFANA_PORT                    = try(local.monitors["grafana"].port, null)
+            MONITOR_GRAFANA_UPTIME_WEBHOOK_URL      = module.uptime.webhook
             MONITOR_JAEGER_COLLECTOR_OTLP_GRPC_HOST = "http://jaegar"
             MONITOR_JAEGER_COLLECTOR_OTLP_GRPC_PORT = try(local.monitors["jaegar"].port, null)
             MONITOR_KUBE_STATE_METRICS_HOST         = "http://kube-state-metrics"


### PR DESCRIPTION
### Issues Closed

- PARA-8155

### Brief Summary

Automates BetterUptime monitor and webhook creation.

### Detailed Summary

Creates BetterUptime monitors for each microservice. Also creates an incoming Grafana webhook and sets the `MONITOR_GRAFANA_UPTIME_WEBHOOK_URL` environment variable with it. Same changes were made in https://github.com/useparagon/on-prem/pull/139.

Changed default EKS version from `1.25` to `1.28` to align with all current deplyments.

### Changes

- created BetterUptime monitors and webhook
- configured Grafana to use the webhook

### Unrelated Changes

- EKS version bump

### Steps to Test

- verify that BetterUptime monitors are created in a group for each microservice
- verify that BetterUptime incoming Grafana webhook is created
- verify that `MONITOR_GRAFANA_UPTIME_WEBHOOK_URL` is set to webhook URL on Grafana task

### QA Notes

none

### Deployment Notes

An API token will have to be created for each deployment here [Better Stack - API tokens](https://betterstack.com/settings/api-tokens/83529) 

These env vars would then be set in `.secure/.env-aws`
```
# monitoring
BETTERUPTIME_API_TOKEN=tOkEnVaLuEfRoMaBoVe
BETTERUPTIME_COMPANY=Some Optional Pretty Name
```

### Screenshots

![image](https://github.com/useparagon/aws-on-prem/assets/114427170/50041589-c371-442e-bf92-e8b4ae1b89ef)

![image](https://github.com/useparagon/aws-on-prem/assets/114427170/2296dafb-57ef-4120-be59-94b00bfdafdb)

![image](https://github.com/useparagon/aws-on-prem/assets/114427170/993439ba-3c48-440a-9962-215c6a6b2363)
