### PR TITLE
chore(infra): upgrade RDS cert and minor version

### DIFF
--- a/terraform/workspaces/infra/postgres/rds.tf
+++ b/terraform/workspaces/infra/postgres/rds.tf
@@ -115,7 +115,7 @@ resource "aws_db_instance" "postgres" {
   max_allocated_storage       = 1000
   iops                        = try(each.value.iops, null)
   allow_major_version_upgrade = false
-  auto_minor_version_upgrade  = false
+  auto_minor_version_upgrade  = true
   availability_zone           = var.multi_az_enabled ? null : var.availability_zones.names[0]
   backup_retention_period     = 7
   monitoring_interval         = 15
@@ -123,6 +123,7 @@ resource "aws_db_instance" "postgres" {
   monitoring_role_arn         = aws_iam_role.rds_enhanced_monitoring.arn
   backup_window               = "06:00-07:00"
   maintenance_window          = "Tue:04:00-Tue:05:00"
+  ca_cert_identifier          = "rds-ca-rsa2048-g1"
 
   db_subnet_group_name      = aws_db_subnet_group.postgres.id
   vpc_security_group_ids    = [aws_security_group.postgres.id]


### PR DESCRIPTION
### Brief Summary

Upgrades RDS CA certificate to a newer version.

### Detailed Summary

Prior to January 26, 2024 the default RDS CA certificate was `rds-ca-2019`. This is set to expire on August 22, 2024. So any databases using the default `ca_cert_identifier` will have to be upgraded by setting the value explicitly to the new default value `rds-ca-rsa2048-g1`. 

### Changes

- explicitly set RDS `ca_cert_identifier` to `rds-ca-rsa2048-g1`

### Unrelated Changes

- enabled auto minor upgrades for security and consistency across environments

### Steps to Test

- Verify that certificate details reflect those in screenshots.

### Deployment Notes

Versions of Postgres prior to 12.11 will require a restart which means 1-2 minutes of downtime.

### Screenshots

![image](https://github.com/useparagon/aws-on-prem/assets/114427170/d6ad8954-7ca4-442d-aa5f-04b4eddf89ca)

![image](https://github.com/useparagon/aws-on-prem/assets/114427170/9d44978f-f008-46ad-adf8-ee95f9f9e0da)
