### PR TITLE
terraform prep without docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,13 @@ deploy-paragon:
 		--mount source="$(shell pwd)",target=/usr/src/app,type=bind \
 		--rm useparagon/aws-self-hosted:latest \
 		ts-node "scripts/cli" deploy-paragon
+
+####################
+# Prepare Terraform files without Docker
+####################
+
+prepare-infra:
+	ts-node "scripts/cli" prepare-infra
+
+prepare-paragon:
+	ts-node "scripts/cli" prepare-paragon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",

--- a/scripts/cli/base.cli.ts
+++ b/scripts/cli/base.cli.ts
@@ -111,7 +111,26 @@ export abstract class BaseCLI {
           .action(async (): Promise<void> => {
             await this.runStateOutput();
           }),
+      )
+      .addCommand(
+        new commander.Command(`prepare-${this.workspace}`)
+          .description('Prepare the Terraform vars.auto.tfvars file.')
+          .action(async (): Promise<void> => {
+            await this.runPrepare();
+          }),
       );
+  }
+
+  /**
+   * prepares Terraform vars for execution outside of Docker
+   */
+  async runPrepare(): Promise<void> {
+    console.log('ℹ️  Executing runPrepare...');
+
+    const env: TerraformEnv = await this.getTerraformEnv();
+    await this.prepareTerraformVariables(env);
+
+    console.log('✅ Executed runPrepare.');
   }
 
   /**

--- a/terraform/workspaces/paragon/outputs.tf
+++ b/terraform/workspaces/paragon/outputs.tf
@@ -31,3 +31,18 @@ output "alb_arn" {
   description = "The ARN of the application load balancer."
   value       = module.alb.alb_arn
 }
+
+output "uptime_webhook" {
+  description = "Uptime webhook URL"
+  value       = module.uptime.webhook
+}
+
+output "uptime_monitors" {
+  description = "Uptime monitor names"
+  value       = module.uptime.monitors
+}
+
+output "uptime_microservices" {
+  description = "Uptime enabled microservices"
+  value       = module.uptime.microservices
+}

--- a/terraform/workspaces/paragon/uptime/outputs.tf
+++ b/terraform/workspaces/paragon/uptime/outputs.tf
@@ -2,3 +2,11 @@ output "webhook" {
   value     = local.enabled ? betteruptime_grafana_integration.webhook[0].webhook_url : ""
   sensitive = true
 }
+
+output "monitors" {
+  value = betteruptime_monitor.monitor[*].pronounceable_name
+}
+
+output "microservices" {
+  value = keys(var.microservices)
+}


### PR DESCRIPTION
### Issues Closed

- PARA-10430

### Detailed Summary

Added `prepare-infra` and `prepare-paragon` CLI commands that will create and populate the relevant `vars.auto.tfvars` files. This will allow Terraform to be run locally without Docker when necessary. Unlike the deploy commands, these commands don't touch the Terraform token file, main.tf or attempt any other Terraform operations.

Also added some output variables for the uptime module to help debug when Better Uptime monitors are not created.