### PR TITLE
Account microservice

### DIFF
--- a/scripts/cli/base.cli.ts
+++ b/scripts/cli/base.cli.ts
@@ -299,6 +299,20 @@ credentials "app.terraform.io" {
     const sanitizedParagonVersion: string = paragonVersion.split('-rc')[0].split('-unstable')[0];
     const microservices: Microservice[] = Object.values(Microservice);
     return microservices.filter((microservice: Microservice): boolean => {
+      // account was added in v3.4.3
+      const hasAccount: boolean =
+        isLatest || compareVersions(sanitizedParagonVersion, 'v3.4.3') >= 0;
+      if (!hasAccount && Microservice.ACCOUNT === microservice) {
+        return false;
+      }
+
+      // chronos was removed in v3.4.3
+      const hasChronos: boolean =
+        !isLatest && compareVersions(sanitizedParagonVersion, 'v3.4.3') < 0;
+      if (!hasChronos && Microservice.CHRONOS === microservice) {
+        return false;
+      }
+
       // pheme was added in v2.64.1
       const hasPheme: boolean =
         isLatest || compareVersions(sanitizedParagonVersion, 'v2.64.0') >= 0;

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -10,6 +10,7 @@ export const PARAGON_WORKSPACE_DIR: string = `${TERRAFORM_WORKSPACES_DIR}/parago
  * old and current microservices
  */
 export enum Microservice {
+  ACCOUNT = 'account',
   CERBERUS = 'cerberus',
   CHRONOS = 'chronos',
   CONNECT = 'connect',

--- a/terraform/workspaces/paragon/helm/helm.tf
+++ b/terraform/workspaces/paragon/helm/helm.tf
@@ -1,6 +1,8 @@
 locals {
   supported_microservices_values = <<EOF
 subchart:
+  account:
+    enabled: ${contains(keys(var.microservices), "account")}
   cerberus:
     enabled: ${contains(keys(var.microservices), "cerberus")}
   chronos:

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -164,6 +164,11 @@ locals {
   })
 
   _microservices = {
+    "account" = {
+      "port"             = lookup(local.base_helm_values.global.env, "ACCOUNT_PORT", 1708)
+      "healthcheck_path" = "/healthz"
+      "public_url"       = lookup(local.base_helm_values.global.env, "ACCOUNT_PUBLIC_URL", "https://account.${var.domain}")
+    }
     "cerberus" = {
       "port"             = lookup(local.base_helm_values.global.env, "CERBERUS_PORT", 1700)
       "healthcheck_path" = "/healthz"
@@ -339,6 +344,7 @@ locals {
           SENDGRID_API_KEY      = "SG.xxx"
           SENDGRID_FROM_ADDRESS = "not-a-real@email.com"
 
+          ACCOUNT_PUBLIC_URL   = try(local.microservices.account.public_url, null)
           CERBERUS_PUBLIC_URL  = try(local.microservices.cerberus.public_url, null)
           CHRONOS_PUBLIC_URL   = try(local.microservices.chronos.public_url, null)
           CONNECT_PUBLIC_URL   = try(local.microservices.connect.public_url, null)
@@ -429,6 +435,7 @@ locals {
             MINIO_INSTANCE_COUNT = "1"
             MINIO_REGION         = var.aws_region
 
+            ACCOUNT_PORT   = try(local.microservices.account.port, null)
             CERBERUS_PORT  = try(local.microservices.cerberus.port, null)
             CHRONOS_PORT   = try(local.microservices.chronos.port, null)
             CONNECT_PORT   = try(local.microservices.connect.port, null)
@@ -451,6 +458,7 @@ locals {
             WORKER_TRIGGERS_PORT    = try(local.microservices["worker-triggers"].port, null)
             WORKER_WORKFLOWS_PORT   = try(local.microservices["worker-workflows"].port, null)
 
+            ACCOUNT_PRIVATE_URL  = try("http://account:${local.microservices.account.port}", null)
             CERBERUS_PRIVATE_URL  = try("http://cerberus:${local.microservices.cerberus.port}", null)
             CHRONOS_PRIVATE_URL   = try("http://chronos:${local.microservices.chronos.port}", null)
             CONNECT_PRIVATE_URL   = try("http://connect:${local.microservices.connect.port}", null)


### PR DESCRIPTION
### Issues Closed

- PARA-10555

### Brief Summary

adds `account` service + removes `chronos`

### Detailed Summary

The `chronos` microservice was removed in v3.4.3 and replaced with a new microservice called `account`. This PR adds the relevant charts and logic to conditionally deploy the services based on semver.

### Changes

- added `account` microservice + networking configs
- added logic to conditionally deploy `chronos` and `account` based on semver