### PR TITLE
feat(monitor): switch vpc flow logs from cloudwatch to s3

### DIFF
--- a/terraform/workspaces/infra/network/logs.tf
+++ b/terraform/workspaces/infra/network/logs.tf
@@ -48,7 +48,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
     status = "Enabled"
 
     transition {
-      days          = 30
+      days          = 7
       storage_class = "GLACIER"
     }
   }

--- a/terraform/workspaces/infra/network/logs.tf
+++ b/terraform/workspaces/infra/network/logs.tf
@@ -1,17 +1,73 @@
 resource "aws_flow_log" "main" {
-  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
-  log_destination = aws_cloudwatch_log_group.main.arn
-  traffic_type    = "ALL"
-  vpc_id          = aws_vpc.app.id
+  log_destination_type = "s3"
+  log_destination      = aws_s3_bucket.flow_logs.arn
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.app.id
 
   tags = {
     Name = "${var.workspace}-vpc-logs"
   }
 }
 
+resource "aws_s3_bucket" "flow_logs" {
+  bucket = "${var.workspace}-vpc-logs"
+}
+
+resource "aws_s3_bucket_versioning" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    id     = "abort-incomplete"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  rule {
+    id     = "transition-to-glacier"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+  }
+
+  rule {
+    id     = "expire"
+    status = "Enabled"
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+// TODO this is no longer used but skip_destroy must be applied before removing to avoid data loss
 resource "aws_cloudwatch_log_group" "main" {
   name_prefix       = "${var.workspace}-vpc-logs"
   retention_in_days = 365
+  skip_destroy      = true
 
   tags = {
     Name = "${var.workspace}-vpc-logs"

--- a/terraform/workspaces/infra/network/network.tf
+++ b/terraform/workspaces/infra/network/network.tf
@@ -100,3 +100,18 @@ resource "aws_route_table_association" "private" {
   subnet_id      = element(aws_subnet.private.*.id, count.index)
   route_table_id = element(aws_route_table.private.*.id, count.index)
 }
+
+# VPC endpoint for S3 to bypass NAT Gateway for cost savings
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_vpc.app.id
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+
+  route_table_ids = concat(
+    aws_route_table.private.*.id,
+    [aws_vpc.app.main_route_table_id]
+  )
+
+  tags = {
+    Name = "${var.workspace}-s3-endpoint"
+  }
+}

--- a/terraform/workspaces/infra/network/security.tf
+++ b/terraform/workspaces/infra/network/security.tf
@@ -1,43 +1,71 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role" "vpc_flow_logs" {
   name_prefix = "${var.workspace}-vpc-logs"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = jsonencode(
     {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "vpc-flow-logs.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "AllowFlowLogsToS3",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "vpc-flow-logs.amazonaws.com"
+          },
+          "Action" : "sts:AssumeRole"
+        }
+      ]
     }
-  ]
-}
-EOF
+  )
 }
 
 resource "aws_iam_role_policy" "vpc_flow_logs" {
   name_prefix = "${var.workspace}-vpc-logs"
   role        = aws_iam_role.vpc_flow_logs.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  policy = jsonencode(
     {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "AWSLogDeliveryWrite",
+          "Effect" : "Allow",
+          "Action" : "s3:PutObject",
+          "Resource" : "${aws_s3_bucket.flow_logs.arn}/*",
+          "Condition" : {
+            "StringEquals" : {
+              "aws:SourceAccount" : data.aws_caller_identity.current.account_id,
+              "s3:x-amz-acl" : "bucket-owner-full-control"
+            }
+          }
+        },
+        {
+          "Sid" : "AWSLogDeliveryAclCheck",
+          "Effect" : "Allow",
+          "Action" : [
+            "s3:GetBucketAcl",
+            "s3:ListBucket"
+          ],
+          "Resource" : aws_s3_bucket.flow_logs.arn,
+          "Condition" : {
+            "StringEquals" : {
+              "aws:SourceAccount" : data.aws_caller_identity.current.account_id
+            }
+          }
+          }, {
+          "Sid" : "AWSLogKMSKeys",
+          "Effect" : "Allow",
+          "Action" : [
+            "kms:Encrypt*",
+            "kms:Decrypt*",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:Describe*"
+          ],
+          "Resource" : "*"
+        }
+      ]
     }
-  ]
-}
-EOF
+  )
 }

--- a/terraform/workspaces/paragon/.terraform.lock.hcl
+++ b/terraform/workspaces/paragon/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/betterstackhq/better-uptime" {
   version = "0.6.1"
   hashes = [
+    "h1:Js6vyhkkkbF33ruBI5ZHGzLuSl20t3LvBVMMeP1oclI=",
     "h1:PoYW4p9l/O0H0NbN/kqNG51cCcyRVaO5gPnLXiAl+Ds=",
     "zh:0281d80170429bd39cd7c3e431b7b45dddf1be22b703e2ea6dc534ffc9f70f7f",
     "zh:1666632f0a8ef1c018ef85ee52e8434c2343479a82312e626b51c9d616de8654",

--- a/terraform/workspaces/paragon/uptime/monitors.tf
+++ b/terraform/workspaces/paragon/uptime/monitors.tf
@@ -26,4 +26,10 @@ resource "betteruptime_monitor" "monitor" {
   email = true
   push  = true
   sms   = true
+
+  # start paused to avoid alarms during initial provisioning
+  paused = true
+  lifecycle {
+    ignore_changes = [paused]
+  }
 }


### PR DESCRIPTION
### Issues Closed

- PARA-9761

### Brief Summary

Switched VPC flow logs from CloudWatch to S3.

### Detailed Summary

Switching the VPC flow logs from CloudWatch to S3 can provide significant cost savings for this infrequently accessed data. An S3 VPC endpoint is also created so these logs bypass the NAT Gateway for additional security and cost savings. The other logging S3 buckets also had their lifecycle configs updated to match the VPC flow logs bucket for more consistent data retention rules and cost savings.

One unrelated change was made to pause the uptime checks by default to avoid alarms in newly provisioned environments.

### Changes

- switched flow logs to S3
- added S3 VPC endpoint
- added lifecycle configs for other log buckets
- paused uptime checks by default