### PR TITLE
chore(infra): added additional redis types that support autoscaling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",

--- a/terraform/workspaces/infra/redis/variables.tf
+++ b/terraform/workspaces/infra/redis/variables.tf
@@ -77,8 +77,8 @@ locals {
   }
 
   # https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoScaling.html
-  # only R5, R6g, M5, M6g families supported
-  cache_autoscaling_supports_family = contains(["r5", "r6g", "m5", "m6g"], element(split(".", lower(var.elasticache_node_type)), 1))
+  # only certain families supported
+  cache_autoscaling_supports_family = contains(["c7gn", "m5", "m6g", "m7g", "r5", "r6g", "r6gd", "r7g"], element(split(".", lower(var.elasticache_node_type)), 1))
   # only large, xlarge, and 2xlarge supported
   cache_autoscaling_supports_size = contains(["large", "xlarge", "2xlarge"], element(split(".", lower(var.elasticache_node_type)), 2))
   cache_autoscaling_enabled       = var.multi_redis && local.cache_autoscaling_supports_family && local.cache_autoscaling_supports_size


### PR DESCRIPTION
### Issues Closed

- PARA-11366

### Summary

Added additional AWS Elasticache family types that support autoscaling. See [Auto Scaling ElastiCache (Redis OSS) clusters](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoScaling.html) for more details.