### PR TITLE
chore(infra): update EKS version to 1.31

### DIFF
--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -103,7 +103,7 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
 
   cluster_name             = var.workspace
   addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.19.0-eksbuild.2"
+  addon_version            = "v1.32.0-eksbuild.1"
   resolve_conflicts        = "OVERWRITE"
   service_account_role_arn = module.aws_ebs_csi_driver_iam_role[0].iam_role_arn
 

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -136,7 +136,7 @@ variable "multi_redis" {
 variable "k8_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
-  default     = "1.30"
+  default     = "1.31"
 }
 
 variable "k8_ondemand_node_instance_type" {

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -136,7 +136,7 @@ variable "multi_redis" {
 variable "k8_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
-  default     = "1.28"
+  default     = "1.30"
 }
 
 variable "k8_ondemand_node_instance_type" {


### PR DESCRIPTION
### Issues Closed

- PARA-11579

### Brief Summary

Updates Terraform to support EKS Kubernetes engine 1.31.

### Detailed Summary

No chart changes were required. None are expected for 1.32 support either. The EBS CSI had issues with the latest version. `v1.32.0-eksbuild.1` is compatible with EKS 1.28 - 1.32. This update buys us until November 26, 2025 before another update is needed.

### Changes

- updated EBS CSI add-on version
- updated default `k8_version`

### Unrelated Changes

None

### Future Work

All on-prem AWS environments will need this change in the next 6 weeks before 1.28 enters extended support.

### Steps to Test

Deploy changes and ensure nodes are upgraded and replaced without downtime.

### QA Notes

None

### Deployment Notes

The k8s upgrades have to happen one at a time (1.28 -> 1.29 -> 1.30 -> 1.31).

### Screenshots

![image](https://github.com/user-attachments/assets/80640385-30da-4c64-b3bf-03b27b256f13)
![image](https://github.com/user-attachments/assets/d7afa8cd-2c30-4681-a627-08c8b850775e)

