### PR TITLE
fix(infra): EBS and KMS security improvements

### DIFF
--- a/terraform/workspaces/infra/bastion/ec2.tf
+++ b/terraform/workspaces/infra/bastion/ec2.tf
@@ -50,8 +50,7 @@ resource "random_string" "bastion_id" {
 }
 
 module "bastion" {
-  source  = "Guimove/bastion/aws"
-  version = "3.0.6"
+  source = "github.com/useparagon/terraform-aws-bastion"
 
   # logging
   bucket_name     = local.resource_group

--- a/terraform/workspaces/infra/cluster/variables.tf
+++ b/terraform/workspaces/infra/cluster/variables.tf
@@ -83,6 +83,12 @@ variable "k8_max_node_count" {
   type        = number
 }
 
+variable "kms_admin_role" {
+  description = "ARN of IAM role allowed to administer KMS keys."
+  type        = string
+  default     = null
+}
+
 locals {
   node_volume_size = 50
 

--- a/terraform/workspaces/infra/modules.tf
+++ b/terraform/workspaces/infra/modules.tf
@@ -108,6 +108,7 @@ module "cluster" {
   k8_max_node_count                = var.k8_max_node_count
   eks_addon_ebs_csi_driver_enabled = var.eks_addon_ebs_csi_driver_enabled
   eks_admin_user_arns              = local.eks_admin_user_arns
+  kms_admin_role                   = var.kms_admin_role
 
   vpc              = module.network.vpc
   public_subnet    = module.network.public_subnet

--- a/terraform/workspaces/infra/resource-group.tf
+++ b/terraform/workspaces/infra/resource-group.tf
@@ -7,26 +7,3 @@ resource "random_string" "app" {
   lower   = true
   upper   = false
 }
-
-resource "aws_resourcegroups_group" "app" {
-  name        = local.workspace
-  description = "Resources in Paragon enterprise workspace ${local.workspace}"
-
-  resource_query {
-    query = <<JSON
-{
-  "ResourceTypeFilters": ["AWS::AllSupported"],
-  "TagFilters": [
-    {
-      "Key": "Workspace",
-      "Values": ["${local.workspace}"]
-    },
-    {
-      "Key": "Environment",
-      "Values": ["${local.environment}"]
-    }
-  ]
-}
-JSON
-  }
-}

--- a/terraform/workspaces/infra/resource-group.tf
+++ b/terraform/workspaces/infra/resource-group.tf
@@ -7,3 +7,26 @@ resource "random_string" "app" {
   lower   = true
   upper   = false
 }
+
+resource "aws_resourcegroups_group" "app" {
+  name        = local.workspace
+  description = "Resources in Paragon enterprise workspace ${local.workspace}"
+
+  resource_query {
+    query = <<JSON
+{
+  "ResourceTypeFilters": ["AWS::AllSupported"],
+  "TagFilters": [
+    {
+      "Key": "Workspace",
+      "Values": ["${local.workspace}"]
+    },
+    {
+      "Key": "Environment",
+      "Values": ["${local.environment}"]
+    }
+  ]
+}
+JSON
+  }
+}

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -240,6 +240,12 @@ variable "cloudflare_zone_id" {
   default     = null
 }
 
+variable "kms_admin_role" {
+  description = "ARN of IAM role allowed to administer KMS keys."
+  type        = string
+  default     = null
+}
+
 locals {
   workspace   = "paragon-enterprise-${var.organization != null ? var.organization : random_string.app[0].result}"
   environment = "enterprise"

--- a/terraform/workspaces/paragon/helm/helm.tf
+++ b/terraform/workspaces/paragon/helm/helm.tf
@@ -248,7 +248,8 @@ resource "helm_release" "paragon_on_prem" {
 
   depends_on = [
     helm_release.ingress,
-    kubernetes_secret.docker_login
+    kubernetes_secret.docker_login,
+    kubernetes_storage_class_v1.gp3_encrypted
   ]
 }
 
@@ -314,6 +315,7 @@ resource "helm_release" "paragon_logging" {
   depends_on = [
     helm_release.ingress,
     kubernetes_secret.docker_login,
+    kubernetes_storage_class_v1.gp3_encrypted
   ]
 }
 
@@ -438,6 +440,7 @@ resource "helm_release" "paragon_monitoring" {
   depends_on = [
     helm_release.ingress,
     helm_release.paragon_on_prem,
-    kubernetes_secret.docker_login
+    kubernetes_secret.docker_login,
+    kubernetes_storage_class_v1.gp3_encrypted
   ]
 }

--- a/terraform/workspaces/paragon/helm/storage.tf
+++ b/terraform/workspaces/paragon/helm/storage.tf
@@ -1,0 +1,23 @@
+# EKS might create gp2 as a default. That is safe to unset with:
+#   kubectl patch storageclass gp2 -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "false"}}}'
+
+resource "kubernetes_storage_class_v1" "gp3_encrypted" {
+  metadata {
+    name = "gp3-encrypted"
+
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  allow_volume_expansion = true
+  reclaim_policy         = "Delete"
+  storage_provisioner    = "ebs.csi.aws.com"
+  volume_binding_mode    = "WaitForFirstConsumer"
+
+  parameters = {
+    encrypted = "true"
+    fsType    = "ext4"
+    type      = "gp3"
+  }
+}


### PR DESCRIPTION
### Issues Closed

- PARA-11834
- PARA-12103

### Brief Summary

Encrypts bastion EBS volumes. Allows better control of KMS admins. Removes unused resource group.

### Detailed Summary

Switches to using a forked version of the bastion module to provide more fine-grained control over the volume encryption settings.

Allows setting KMS key administrators instead of just defaulting to only the current executing user.

Removes unused resource group to further limit required IAM permissions.

### Changes

- new bastion module
- kms key admin variables
- removed resource group
