### PR TITLE
feat(infra): added flipt microservice

### DIFF
--- a/scripts/cli/base.cli.ts
+++ b/scripts/cli/base.cli.ts
@@ -372,6 +372,13 @@ credentials "app.terraform.io" {
         return false;
       }
 
+      // `flipt` was introduced in v2025.0127.2349
+      const hasFlipt: boolean =
+        isLatest || compareVersions(sanitizedParagonVersion, 'v2025.0127.2348') >= 0;
+      if (!hasFlipt && Microservice.FLIPT === microservice) {
+        return false;
+      }
+
       return true;
     });
   }
@@ -387,8 +394,7 @@ credentials "app.terraform.io" {
     const upgrade: boolean = options.args.includes('-upgrade');
     console.log('ℹ️  Executing `terraform init`...');
     await execAsync(
-      `terraform -chdir=${TERRAFORM_WORKSPACES_DIR}/${this.workspace} init${
-        upgrade ? ' -upgrade' : ''
+      `terraform -chdir=${TERRAFORM_WORKSPACES_DIR}/${this.workspace} init${upgrade ? ' -upgrade' : ''
       }`,
       this.terraformEnv(options.debug),
     );

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -15,6 +15,7 @@ export enum Microservice {
   CHRONOS = 'chronos',
   CONNECT = 'connect',
   DASHBOARD = 'dashboard',
+  FLIPT = 'flipt',
   HADES = 'hades',
   HERCULES = 'hercules',
   HERMES = 'hermes',

--- a/terraform/workspaces/infra/bastion/ec2.tf
+++ b/terraform/workspaces/infra/bastion/ec2.tf
@@ -54,6 +54,7 @@ module "bastion" {
 
   # logging
   bucket_name     = local.resource_group
+  log_auto_clean  = true
   log_expiry_days = 365
 
   # networking

--- a/terraform/workspaces/paragon/alb/dns.tf
+++ b/terraform/workspaces/paragon/alb/dns.tf
@@ -13,7 +13,7 @@ resource "aws_route53_zone" "paragon" {
 }
 
 resource "aws_route53_record" "microservice" {
-  for_each = merge(var.microservices, var.public_monitors)
+  for_each = merge(var.public_microservices, var.public_monitors)
 
   zone_id = aws_route53_zone.paragon.zone_id
   name = replace(

--- a/terraform/workspaces/paragon/alb/variables.tf
+++ b/terraform/workspaces/paragon/alb/variables.tf
@@ -13,7 +13,7 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
-variable "microservices" {
+variable "public_microservices" {
   description = "The microservices running within the system."
   type = map(object({
     port             = number

--- a/terraform/workspaces/paragon/helm/variables.tf
+++ b/terraform/workspaces/paragon/helm/variables.tf
@@ -13,6 +13,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "flipt_options" {
+  description = "Map of flipt configuration variables"
+  type        = map(any)
+  sensitive   = true
+}
+
 variable "docker_registry_server" {
   description = "Docker container registry server."
   type        = string
@@ -63,6 +69,15 @@ variable "acm_certificate_arn" {
 
 variable "microservices" {
   description = "The microservices running within the system."
+  type = map(object({
+    port             = number
+    healthcheck_path = string
+    public_url       = string
+  }))
+}
+
+variable "public_microservices" {
+  description = "The microservices running within the system exposed to the load balancer"
   type = map(object({
     port             = number
     healthcheck_path = string

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -4,7 +4,7 @@ module "alb" {
   acm_certificate_arn      = var.acm_certificate_arn
   aws_workspace            = var.aws_workspace
   domain                   = var.domain
-  microservices            = local.microservices
+  public_microservices     = local.public_microservices
   public_monitors          = local.public_monitors
   dns_provider             = var.dns_provider
   cloudflare_dns_api_token = var.cloudflare_dns_api_token
@@ -24,6 +24,7 @@ module "helm" {
   docker_password        = var.docker_password
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
+  flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme
   k8_version             = var.k8_version
@@ -34,6 +35,7 @@ module "helm" {
   monitors_enabled       = var.monitors_enabled
   openobserve_email      = var.openobserve_email
   openobserve_password   = var.openobserve_password
+  public_microservices   = local.public_microservices
   public_monitors        = local.public_monitors
 
   acm_certificate_arn = module.alb.acm_certificate_arn
@@ -57,5 +59,5 @@ module "uptime" {
 
   uptime_api_token = var.uptime_api_token
   uptime_company   = coalesce(var.uptime_company, var.organization)
-  microservices    = local.microservices
+  microservices    = local.public_microservices
 }


### PR DESCRIPTION
### Issues Closed

- PARA-12897

### Brief Summary

Adds `flipt` feature flag support.

### Detailed Summary

Adds `flipt` as a supported microservice in the setup scripts. Adds optional parameter support and defaults. Sets relevant environment variables. Introduces `public_microservices` support so `flipt` endpoint is not exposed publicly.

### Changes

- added flipt support

### Unrelated Changes

- added bastion log cleanup for SOC2

### Future Work

none

### Steps to Test

- Deploy updated charts and configs
- Verify that flipt pod starts and remains stable
- Verify that other pods reference flipt with `FEATURE_FLAG_PLATFORM_ENDPOINT: http://flipt:1722`
- Verify that flipt UI is accessible and pulling a flag from the repo

### QA Notes

none

### Deployment Notes

- some deployments had flipt installed manually and would need cleanup

### Screenshots

![image](https://github.com/user-attachments/assets/6b4e5276-db40-4c7d-8350-4afe96319be3)

![image](https://github.com/user-attachments/assets/f4c1ef4c-e0a1-49c8-8df1-18087cead0e6)
