### PR TITLE
fix: set ingress ALB ARN for grafana

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",


### PR DESCRIPTION
### Issues Closed

- PARA-13274

### Brief Summary

Set ingress ALB ARN for Grafana AWS ALB dashboards.

### Changes

- set `MONITOR_GRAFANA_ALB_ARN` env var

### Steps to Test

- apply changes and verify that AWS ALB dashboard displays data

### Screenshots

![image](https://github.com/user-attachments/assets/0efaac70-be30-4054-9ee5-aa04590fb0c8)
