### PR TITLE
added local flipt feature flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,42 @@ If you have `MULTI_REDIS` enabled, instead of using `REDIS_*` variables, you'll 
     WORKFLOW_REDIS_CLUSTER_ENABLED: true
 ```
 
-### 8. Deploy the Helm chart.
+### 8. Optionally configure the `.secure/features.yml` file.
+
+If the deployment will not have access to Paragon's `feature-flag` repository for GitOps-based flags then the flags can be configured locally. Paragon can provide an export of this file since the options change regularly. If using Git then this file should not exist. The format will look like this:
+
+```yaml
+namespace: production
+flags:
+  - key: MFA_RECOVERY_CODES_ENABLED
+    description: Enable MFA Recovery Codes
+    name: MFA_RECOVERY_CODES_ENABLED
+    type: BOOLEAN_FLAG_TYPE
+    rollouts:
+      - description: Enabled for Organizations by ID
+        segment:
+          key: mfa-recovery-codes-enabled-organizations
+          value: true
+      - description: Disabled for all other users
+        segment:
+          key: all-users
+          value: false
+  - key: MFA_ENABLED
+    description: Enable MFA
+    name: MFA_ENABLED
+    type: BOOLEAN_FLAG_TYPE
+    rollouts:
+      - description: Enabled for Organizations by ID
+        segment:
+          key: mfa-enabled-organizations
+          value: true
+      - description: Disabled for all other users
+        segment:
+          key: all-users
+          value: false
+```
+
+### 9. Deploy the Helm chart.
 
 Deploy the Paragon helm chart to your Kubernetes cluster. Run the following command:
 
@@ -323,7 +358,7 @@ make -s deploy-paragon
 
 Confirm that Terraform executed successfully.
 
-### 9. Update your nameservers.
+### 10. Update your nameservers.
 
 You’ll need to update the nameservers for your domain to be able to access the services. Run the following command:
 
@@ -333,7 +368,7 @@ make -s state-paragon
 
 Go to the website where you registered your domain (e.g. Namecheap, Cloudflare, Route53), and update the nameservers. If the domain is a subdomain, e.g. `subdomain.domain.com`, you’ll need to add `NS` entries for the subdomain. If the domain is a root domain, e.g. `domain.com`, you’ll need to update the nameservers for the domain.
 
-### 10. Open the application.
+### 11. Open the application.
 
 Visit `https://dashboard.<YOUR_DOMAIN>` on your browser to view the dashboard. Register an account and get started!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",

--- a/scripts/cli/base.cli.ts
+++ b/scripts/cli/base.cli.ts
@@ -270,6 +270,23 @@ credentials "app.terraform.io" {
         `${ROOT_DIR}/.secure/.env-helm`,
       ).catch(() => ({}));
       variables['helm_env'] = Buffer.from(JSON.stringify(helmEnvValues)).toString('base64');
+
+      // Add feature flags if they exist - supports both yml and yaml since our values.yaml naming is inconsistent from flipt's yml
+      const featureFlagExtensions = ['yml', 'yaml'];
+      let featureFlagsContent: string | null = null;
+
+      // Loop through extensions, preferring yml over yaml
+      for (const ext of featureFlagExtensions) {
+        const featureFlagsPath = `${ROOT_DIR}/.secure/features.${ext}`;
+        if (fs.existsSync(featureFlagsPath)) {
+          featureFlagsContent = await fs.promises.readFile(featureFlagsPath, 'utf-8');
+          break;
+        }
+      }
+
+      if (featureFlagsContent) {
+        variables['feature_flags'] = Buffer.from(featureFlagsContent).toString('base64');
+      }
     }
 
     const outputFile: string = Object.keys(variables)

--- a/terraform/workspaces/infra/bastion/variables.tf
+++ b/terraform/workspaces/infra/bastion/variables.tf
@@ -97,6 +97,5 @@ locals {
     ResourceGroup = local.resource_group
   })
 
-  # TODO: update to random port
   ssh_port = 22
 }

--- a/terraform/workspaces/infra/network/logs.tf
+++ b/terraform/workspaces/infra/network/logs.tf
@@ -62,14 +62,3 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
     }
   }
 }
-
-// TODO this is no longer used but skip_destroy must be applied before removing to avoid data loss
-resource "aws_cloudwatch_log_group" "main" {
-  name_prefix       = "${var.workspace}-vpc-logs"
-  retention_in_days = 365
-  skip_destroy      = true
-
-  tags = {
-    Name = "${var.workspace}-vpc-logs"
-  }
-}

--- a/terraform/workspaces/paragon/alb/dns.tf
+++ b/terraform/workspaces/paragon/alb/dns.tf
@@ -38,5 +38,5 @@ resource "cloudflare_record" "nameserver" {
   zone_id = var.cloudflare_zone_id
   value   = aws_route53_zone.paragon.name_servers[count.index]
   type    = "NS"
-  ttl     = 60 # TODO: increase the TTL to `600` (10 MINUTES) when stable
+  ttl     = 600
 }

--- a/terraform/workspaces/paragon/helm/variables.tf
+++ b/terraform/workspaces/paragon/helm/variables.tf
@@ -13,6 +13,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "feature_flags_content" {
+  description = "Optional YAML content for feature flags when not using a git repository."
+  type        = string
+  default     = null
+}
+
 variable "flipt_options" {
   description = "Map of flipt configuration variables"
   type        = map(any)

--- a/terraform/workspaces/paragon/modules.tf
+++ b/terraform/workspaces/paragon/modules.tf
@@ -24,6 +24,7 @@ module "helm" {
   docker_password        = var.docker_password
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
+  feature_flags_content  = local.feature_flags_content
   flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -105,6 +105,12 @@ variable "helm_env" {
   type        = string
 }
 
+variable "feature_flags" {
+  description = "Base64 encoded feature flags YAML content."
+  type        = string
+  default     = null
+}
+
 variable "ingress_scheme" {
   description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
   type        = string
@@ -559,17 +565,22 @@ locals {
 
   monitor_version = var.monitor_version != null ? var.monitor_version : try(local.helm_values.global.env["VERSION"], "latest")
 
+  feature_flags_content = var.feature_flags != null ? base64decode(var.feature_flags) : null
+
   flipt_options = {
     for key, value in merge(
       # user overrides
       local.base_helm_values.global.env,
       {
         FLIPT_CACHE_ENABLED             = "true"
+        FLIPT_LOG_GRPC_LEVEL            = "warn"
+        FLIPT_LOG_LEVEL                 = "warn"
         FLIPT_STORAGE_GIT_POLL_INTERVAL = "30s"
         FLIPT_STORAGE_GIT_REF           = "main"
-        FLIPT_STORAGE_GIT_REPOSITORY    = "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_GIT_REPOSITORY    = local.feature_flags_content != null ? null : "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_LOCAL_PATH        = local.feature_flags_content != null ? "/var/opt/flipt" : null
         FLIPT_STORAGE_READ_ONLY         = "true"
-        FLIPT_STORAGE_TYPE              = "git"
+        FLIPT_STORAGE_TYPE              = local.feature_flags_content != null ? "local" : "git"
     }) :
     key => value
     if key != null && key != "" && value != null && value != "" && can(regex("^FLIPT_", key))

--- a/terraform/workspaces/paragon/variables.tf
+++ b/terraform/workspaces/paragon/variables.tf
@@ -106,7 +106,7 @@ variable "helm_env" {
 }
 
 variable "feature_flags" {
-  description = "Base64 encoded feature flags YAML content."
+  description = "Optional base64 encoded feature flags YAML content."
   type        = string
   default     = null
 }


### PR DESCRIPTION
### Issues Closed

- PARA-13377

### Brief Summary

Adds support for local feature flag yaml files.

### Detailed Summary

Air-gapped or unmanaged deployments may not want to pull feature flags from a git repository. Since many new Paragon features are behind feature flags local support is required. This adds the ability to have a `.secure/features.yml` defined locally that will populate a ConfigMap that is mounted to the Flipt pod.

### Changes

- updated TS to populate Terraform variable with base64 string of features.yml
- configured local storage settings vs git repo based on provided features
- creates configMap and volume mounts for features if provided

### Unrelated Changes

- cleaned up some old TODOs

### Future Work

- PARA-13400 implement similar solution in enterprise repo

### Steps to Test

- deploy to AWS with a `.secure/features.yml`
- ensure Flipt pod uses local storage and mounts ConfigMap
- ensure Flipt UI shows production feature flags

### QA Notes

none

### Deployment Notes

The `features.yml` can be exported from the `production` folder of the `feature-flag` repo.

### Screenshots

![image](https://github.com/user-attachments/assets/0d34cd2a-9779-4875-8a85-d2cf1cb8d12a)

![image](https://github.com/user-attachments/assets/2a9a540b-cc7f-4ece-8119-948e07a2cea3)

![image](https://github.com/user-attachments/assets/2a9cfcc2-5b41-4f05-9592-85ef984c7fd9)
