### PR TITLE
rds: added postgres16 param group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ docker_volumes
 # ./charts
 terraform/workspaces/paragon/charts
 !terraform/workspaces/paragon/charts/.gitkeep
+
+*.tfvars
+*.tfstate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",

--- a/terraform/workspaces/infra/postgres/rds.tf
+++ b/terraform/workspaces/infra/postgres/rds.tf
@@ -87,6 +87,54 @@ resource "aws_db_parameter_group" "postgres" {
   }
 }
 
+resource "aws_db_parameter_group" "postgres16" {
+  name   = "${var.workspace}-postgres16-upgrade"
+  family = "postgres16"
+
+  dynamic "parameter" {
+    for_each = [
+      {
+        name         = "log_statement"
+        value        = "ddl"
+        apply_method = "pending-reboot"
+      },
+      {
+        name         = "log_min_duration_statement"
+        value        = 1000
+        apply_method = "pending-reboot"
+      },
+      {
+        name         = "max_connections"
+        value        = 10000
+        apply_method = "pending-reboot"
+      },
+      {
+        name         = "wal_buffers"
+        value        = "2048" # 2MB
+        apply_method = "pending-reboot"
+      },
+      {
+        name         = "rds.logical_replication"
+        value        = 1
+        apply_method = "pending-reboot"
+      },
+    ]
+    content {
+      apply_method = lookup(parameter.value, "apply_method", null)
+      name         = parameter.value.name
+      value        = parameter.value.value
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${var.workspace}-postgres16-upgrade"
+  }
+}
+
 data "aws_db_snapshot" "postgres" {
   for_each = var.rds_restore_from_snapshot ? local.postgres_instances : {}
 

--- a/terraform/workspaces/infra/postgres/rds.tf
+++ b/terraform/workspaces/infra/postgres/rds.tf
@@ -61,11 +61,6 @@ resource "aws_db_parameter_group" "postgres" {
         apply_method = "pending-reboot"
       },
       {
-        name         = "max_connections"
-        value        = 10000
-        apply_method = "pending-reboot"
-      },
-      {
         name         = "wal_buffers"
         value        = "2048" # sets `wal_buffers` to 16mb
         apply_method = "pending-reboot"
@@ -101,11 +96,6 @@ resource "aws_db_parameter_group" "postgres16" {
       {
         name         = "log_min_duration_statement"
         value        = 1000
-        apply_method = "pending-reboot"
-      },
-      {
-        name         = "max_connections"
-        value        = 10000
         apply_method = "pending-reboot"
       },
       {


### PR DESCRIPTION
### Issues Closed

- PARA-13445

### Brief Summary

Adds postgres16 RDS parameter group to prepare for upgrade.

### Detailed Summary

A new database parameter group must be created for postgres 16 to allow the database to be upgraded from 12 to 16 with minimal changes in the AWS Console.

### Changes

- added `postgres16` parameter group

### Unrelated Changes

none

### Future Work

New Helm charts will be needed to ensure zero data loss during the upgrade.

### Steps to Test

Deploy and verify that there are two DB parameter groups. One for the selected `postgres_family` and one for `postgres16`.

### QA Notes

none

### Deployment Notes

none

### Screenshots

![image](https://github.com/user-attachments/assets/e81ec138-7b62-4112-81c0-cd46c9f5f378)
