### PR TITLE
chore(infra): updated default values to support eks 1.32

### DIFF
--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -103,7 +103,7 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
 
   cluster_name             = var.workspace
   addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.32.0-eksbuild.1"
+  addon_version            = "v1.45.0-eksbuild.2"
   resolve_conflicts        = "OVERWRITE"
   service_account_role_arn = module.aws_ebs_csi_driver_iam_role[0].iam_role_arn
 

--- a/terraform/workspaces/infra/postgres/variables.tf
+++ b/terraform/workspaces/infra/postgres/variables.tf
@@ -85,12 +85,6 @@ variable "managed_sync_enabled" {
 
 locals {
   postgres_instances = var.multi_postgres ? merge({
-    beethoven = {
-      name         = "${var.workspace}-beethoven"
-      size         = var.rds_instance_class
-      db           = "beethoven"
-      storage_type = "gp2"
-    }
     cerberus = {
       name         = "${var.workspace}-cerberus"
       size         = "db.t4g.micro"

--- a/terraform/workspaces/infra/variables.tf
+++ b/terraform/workspaces/infra/variables.tf
@@ -46,7 +46,7 @@ variable "vpc_cidr_newbits" {
 variable "rds_instance_class" {
   description = "The RDS instance class type used for Postgres."
   type        = string
-  default     = "db.t3.small"
+  default     = "db.t4g.small"
 }
 
 variable "rds_restore_from_snapshot" {
@@ -70,7 +70,7 @@ variable "elasticache_node_type" {
 variable "postgres_version" {
   description = "Postgres version for the database."
   type        = string
-  default     = "12.7"
+  default     = "16"
 }
 
 variable "multi_postgres" {
@@ -136,19 +136,19 @@ variable "multi_redis" {
 variable "k8_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
-  default     = "1.31"
+  default     = "1.32"
 }
 
 variable "k8_ondemand_node_instance_type" {
   description = "The compute instance type to use for Kubernetes nodes."
   type        = string
-  default     = "t3a.medium,t3.medium"
+  default     = "m6a.xlarge"
 }
 
 variable "k8_spot_node_instance_type" {
   description = "The compute instance type to use for Kubernetes spot nodes."
   type        = string
-  default     = "t3a.medium,t3.medium"
+  default     = "t3a.xlarge,t3.xlarge,m5a.xlarge,m5.xlarge,m6a.xlarge,m6i.xlarge,m7a.xlarge,m7i.xlarge,r5a.xlarge,m4.xlarge"
 }
 
 variable "k8_spot_instance_percent" {
@@ -164,7 +164,7 @@ variable "k8_spot_instance_percent" {
 variable "k8_min_node_count" {
   description = "The minimum number of nodes to run in the Kubernetes cluster."
   type        = number
-  default     = 12
+  default     = 4
 }
 
 variable "k8_max_node_count" {


### PR DESCRIPTION
### Issues Closed

- PARA-14665

### Brief Summary

Upgraded EKS cluster, addons and spot instance type list defaults

### Detailed Summary

Upgraded default EKS version from `1.31` to `1.32` to avoid end of support in Nov 2025. 

Increased spot instance type list to include additional types. This will help avoid spot evictions and lessen the impact if/when they do happen.

Updated other default variables values to match current deployments. 

Removed unused legacy `beethoven` database to improve ongoing maintenance. 

### Changes

- terraform variable updates

### Unrelated Changes

- none

### Future Work

- The use of `AL2_x86_64` AMIs will force these environments to migrate to the `enterprise` repo. But that work is already planned.

### Steps to Test

Deploy updated charts and Terraform to AWS.

### Screenshots

<img width="2846" height="1544" alt="image" src="https://github.com/user-attachments/assets/a0c5e015-bae3-49bd-aafa-e31ccec342d7" />
