### PR TITLE
feat(eks): added explicit add-on installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useparagon/aws-on-prem",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Deploy Paragon to your own AWS cloud.",
   "repository": "git@github.com:useparagon/aws-on-prem.git",
   "author": "Paragon Engineering",

--- a/terraform/workspaces/infra/cluster/cluster.tf
+++ b/terraform/workspaces/infra/cluster/cluster.tf
@@ -10,6 +10,21 @@ module "eks" {
   cluster_endpoint_public_access = true
   create_aws_auth_configmap      = true
 
+  cluster_addons = {
+    coredns = {
+      most_recent       = true
+      resolve_conflicts = "OVERWRITE"
+    }
+    kube-proxy = {
+      most_recent       = true
+      resolve_conflicts = "OVERWRITE"
+    }
+    vpc-cni = {
+      most_recent       = true
+      resolve_conflicts = "OVERWRITE"
+    }
+  }
+
   aws_auth_roles = concat([
     {
       rolearn  = aws_iam_role.node_role.arn


### PR DESCRIPTION
### Issues Closed

- PARA-15166

### Brief Summary

Adds explicit management of required EKS add-ons.

### Detailed Summary

The following add-ons are implicitly added to EKS clusters by AWS: `coredns`, `kube-proxy` and `vpc-cni`. However they then don’t appear the in the AWS Console under the list of add-ons and they don’t get automatically upgraded when the cluster is upgraded. This can lead to version incompatibilities between the cluster and add-ons which results in network connectivity issues in the nodes. This will make the add-ons explicitly managed using the latest compatible version.

### Changes

- added EKS add-ons to terraform

### Deployment Notes

- the pods in the `kube-system` namespace should be monitored while this is being applied

### Screenshots

Before
<img width="3306" height="1686" alt="image" src="https://github.com/user-attachments/assets/cf8c6c64-68b9-4434-b20e-cddc13ffa71d" />

After
<img width="3282" height="1946" alt="image" src="https://github.com/user-attachments/assets/555d938e-4f0a-452c-9e63-ecff8dca6478" />
