### PR TITLE
added code owner to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @useparagon/lead-infrastructure-team


### PR DESCRIPTION
### Issues Closed

- PARA-15263

### Brief Summary

Add `CODEOWNERS`  to the repository
### Detailed Summary

This pr adds `infrastructure` team as code owner for this repository

